### PR TITLE
Update GitHub Actions runner to support iOS 26.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Run Tests
@@ -16,4 +16,4 @@ jobs:
           xcodebuild test \
             -workspace MindEcho.xcworkspace \
             -scheme MindEcho \
-            -destination 'platform=iOS Simulator,name=iPhone 16'
+            -destination 'platform=iOS Simulator,name=iPhone 17'


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `macos-latest` to `macos-26` to support iOS 26.2 deployment target
- Update simulator device from `iPhone 16` to `iPhone 17` (available in macos-26 runner)

## Problem
The CI tests were failing because the project's `IPHONEOS_DEPLOYMENT_TARGET` is set to 26.2, but `macos-latest` runner only supports up to iOS 18.5.99.

Error from logs:
```
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 26.2, 
but the range of supported deployment target versions is 12.0 to 18.5.99.
```

## Solution
Use `macos-26` runner which includes:
- Xcode 26.2 (default)
- iOS 26.2 simulator support
- iPhone 17 and other newer device simulators

## Test Results
Before: 
- ❌ `MindEchoUITests.testExample()` - Failed (timeout)
- ❌ `MindEchoUITests.testLaunchPerformance()` - Failed (timeout)

Expected after this change:
- ✅ All tests should pass with proper iOS 26.2 support

🤖 Generated with [Claude Code](https://claude.com/claude-code)