### PR TITLE
Add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,28 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (github.event.action == 'assigned' || github.event.action == 'labeled'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- PRやIssueで `@claude` メンションするとClaude Codeが自動応答するGitHub Actionsワークフローを追加
- `issue_comment`, `pull_request_review_comment`, `issues`, `pull_request_review` イベントに対応
- `ANTHROPIC_API_KEY` シークレットの設定が必要

## Test plan
- [ ] リポジトリの Settings > Secrets に `ANTHROPIC_API_KEY` を設定
- [ ] PRコメントで `@claude` をメンションして応答を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)