### PR TITLE
Add real-time waveform feedback during recording

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,10 @@ jobs:
             {
               "language": "Japanese"
             }
+          claude_args: |
+            --model claude-opus-4-1-20250805
+            --max-turns 10
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
 

--- a/MindEcho/MindEcho.xcodeproj/project.pbxproj
+++ b/MindEcho/MindEcho.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0BA1C00100000001000000A1 /* MindEchoCore in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000003000000A3 /* MindEchoCore */; };
 		0BA1C00100000002000000A2 /* MindEchoAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000004000000A4 /* MindEchoAudio */; };
+		0BA1C00100000007000000A7 /* DSWaveformImage in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000009000000A9 /* DSWaveformImage */; };
+		0BA1C00100000008000000A8 /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C0010000000A000000AA /* DSWaveformImageViews */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +66,8 @@
 			files = (
 				0BA1C00100000001000000A1 /* MindEchoCore in Frameworks */,
 				0BA1C00100000002000000A2 /* MindEchoAudio in Frameworks */,
+				0BA1C00100000007000000A7 /* DSWaveformImage in Frameworks */,
+				0BA1C00100000008000000A8 /* DSWaveformImageViews in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +132,8 @@
 			packageProductDependencies = (
 				0BA1C00100000003000000A3 /* MindEchoCore */,
 				0BA1C00100000004000000A4 /* MindEchoAudio */,
+				0BA1C00100000009000000A9 /* DSWaveformImage */,
+				0BA1C0010000000A000000AA /* DSWaveformImageViews */,
 			);
 			productName = MindEcho;
 			productReference = 0BD6D7FA2F3856DE00D7656F /* MindEcho.app */;
@@ -214,6 +220,7 @@
 			packageReferences = (
 				0BA1C00100000005000000A5 /* XCLocalSwiftPackageReference "../Packages/MindEchoCore" */,
 				0BA1C00100000006000000A6 /* XCLocalSwiftPackageReference "../Packages/MindEchoAudio" */,
+				0BA1C0010000000B000000AB /* XCRemoteSwiftPackageReference "DSWaveformImage" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0BD6D7FB2F3856DE00D7656F /* Products */;
@@ -618,6 +625,17 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		0BA1C0010000000B000000AB /* XCRemoteSwiftPackageReference "DSWaveformImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/dmrschmidt/DSWaveformImage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 14.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		0BA1C00100000003000000A3 /* MindEchoCore */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -626,6 +644,16 @@
 		0BA1C00100000004000000A4 /* MindEchoAudio */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MindEchoAudio;
+		};
+		0BA1C00100000009000000A9 /* DSWaveformImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BA1C0010000000B000000AB /* XCRemoteSwiftPackageReference "DSWaveformImage" */;
+			productName = DSWaveformImage;
+		};
+		0BA1C0010000000A000000AA /* DSWaveformImageViews */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BA1C0010000000B000000AB /* XCRemoteSwiftPackageReference "DSWaveformImage" */;
+			productName = DSWaveformImageViews;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MindEcho/MindEcho.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MindEcho/MindEcho.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "2feb6169e64fdaac107735fe36b78f139e6cb5ad9dfc4abc03e78f3ccd94ad3c",
+  "pins" : [
+    {
+      "identity" : "dswaveformimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dmrschmidt/DSWaveformImage",
+      "state" : {
+        "revision" : "a7a96cf4478c6fa084e76c175bcf7f4c9a38f80a",
+        "version" : "14.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift
+++ b/MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift
@@ -6,6 +6,7 @@ import Observation
 class MockAudioRecorderService: AudioRecording {
     var isRecording = false
     var isPaused = false
+    var audioLevels: [Float] = []
     private(set) var recordingURL: URL?
 
     func startRecording(to url: URL) throws {

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -41,6 +41,7 @@ class HomeViewModel {
 
     var isRecording: Bool { audioRecorder.isRecording }
     var isRecordingPaused: Bool { audioRecorder.isPaused }
+    var audioLevels: [Float] { audioRecorder.audioLevels }
 
     // MARK: - Recording
 

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -1,3 +1,5 @@
+import DSWaveformImage
+import DSWaveformImageViews
 import MindEchoAudio
 import MindEchoCore
 import SwiftData
@@ -25,11 +27,22 @@ struct HomeView: View {
 
                 Spacer()
 
-                // Recording duration (shown when recording)
+                // Recording duration and waveform (shown when recording)
                 if viewModel.isRecording {
                     Text(formatDuration(viewModel.recordingDuration))
                         .font(.system(.largeTitle, design: .monospaced))
                         .accessibilityIdentifier("home.recordingDuration")
+
+                    WaveformLiveCanvas(
+                        samples: viewModel.audioLevels,
+                        configuration: Waveform.Configuration(
+                            style: .striped(.init(color: .red, width: 3, spacing: 2)),
+                            damping: .init()
+                        ),
+                        shouldDrawSilencePadding: true
+                    )
+                    .frame(height: 60)
+                    .opacity(viewModel.isRecordingPaused ? 0.5 : 1.0)
                 }
 
                 // Recording controls

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
@@ -80,9 +80,10 @@ public class AudioRecorderService: AudioRecording {
             }
             let rms = sqrt(sum / Float(frameLength))
 
-            // Match DSWaveformImage reference: 1 - pow(10, averagePower / 20)
-            // which simplifies to (1 - rms) when averagePower = 20*log10(rms).
-            let level = 1 - rms
+            // Amplify raw RMS (typically 0.01-0.1 for speech) so the
+            // waveform is visually responsive, then convert for the renderer
+            // which internally does `1 - sample` to get bar height.
+            let level = 1 - min(rms * 10, 1)
 
             // Append 3 copies per callback to match Voice Memos animation speed.
             DispatchQueue.main.async {

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
@@ -80,13 +80,9 @@ public class AudioRecorderService: AudioRecording {
             }
             let rms = sqrt(sum / Float(frameLength))
 
-            // Convert to dB and normalize for WaveformLiveCanvas.
-            // The renderer internally does `1 - sample` to get bar height,
-            // so we must pass inverted values: silence ≈ 1.0, loud ≈ 0.0.
-            let db = 20 * log10(max(rms, 1e-6))
-            let minDb: Float = -50
-            let maxDb: Float = 0
-            let level = 1 - max(0, min(1, (db - minDb) / (maxDb - minDb)))
+            // Match DSWaveformImage reference: 1 - pow(10, averagePower / 20)
+            // which simplifies to (1 - rms) when averagePower = 20*log10(rms).
+            let level = 1 - rms
 
             // Append 3 copies per callback to match Voice Memos animation speed.
             DispatchQueue.main.async {

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol AudioRecording {
     var isRecording: Bool { get }
     var isPaused: Bool { get }
+    var audioLevels: [Float] { get }
     func startRecording(to url: URL) throws
     func pauseRecording()
     func resumeRecording()

--- a/docs/plans/2026-02-15-waveform-implementation.md
+++ b/docs/plans/2026-02-15-waveform-implementation.md
@@ -1,0 +1,310 @@
+# Waveform Feedback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add real-time audio waveform visualization during recording using DSWaveformImage library.
+
+**Architecture:** AudioRecorderService extracts RMS levels from the existing AVAudioEngine tap callback and exposes them as `[Float]`. HomeViewModel forwards this data to HomeView, which renders it via DSWaveformImage's `WaveformLiveCanvas`.
+
+**Tech Stack:** SwiftUI, AVFoundation, DSWaveformImage v14.x (SPM)
+
+**Design Doc:** `docs/plans/2026-02-12-recording-waveform-design.md`
+
+---
+
+### Task 1: Add DSWaveformImage SPM dependency to Xcode project
+
+**Files:**
+- Modify: `MindEcho/MindEcho.xcodeproj/project.pbxproj`
+
+**Step 1: Add the SPM package via xcodebuild**
+
+Use `xcodebuild -addPackage` or manually add via Swift Package resolution. Since Xcode project modification via CLI for SPM is limited, use the following approach:
+
+```bash
+# Open Xcode and add manually, OR use swift package tools
+# The package URL is: https://github.com/dmrschmidt/DSWaveformImage
+# Version requirement: from 14.0.0
+```
+
+Alternatively, add to the project by editing `project.pbxproj` to include:
+- Remote package reference: `https://github.com/dmrschmidt/DSWaveformImage`
+- Version: `14.0.0` up to next major
+- Products to link: `DSWaveformImage`, `DSWaveformImageViews`
+
+**Step 2: Verify the dependency resolves**
+
+Run:
+```bash
+xcodebuild -resolvePackageDependencies \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho
+```
+Expected: resolves without errors.
+
+**Step 3: Verify build still succeeds**
+
+Run:
+```bash
+xcodebuild build \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: BUILD SUCCEEDED
+
+**Step 4: Commit**
+
+```bash
+git add MindEcho/MindEcho.xcodeproj/project.pbxproj
+git commit -m "Add DSWaveformImage v14 SPM dependency"
+```
+
+---
+
+### Task 2: Add audioLevels to AudioRecording protocol and MockAudioRecorderService
+
+**Files:**
+- Modify: `Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift`
+- Modify: `MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift`
+
+**Step 1: Add audioLevels property to AudioRecording protocol**
+
+In `Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift`, add a new property:
+
+```swift
+public protocol AudioRecording {
+    var isRecording: Bool { get }
+    var isPaused: Bool { get }
+    var audioLevels: [Float] { get }
+    func startRecording(to url: URL) throws
+    func pauseRecording()
+    func resumeRecording()
+    func stopRecording()
+}
+```
+
+**Step 2: Update MockAudioRecorderService to conform**
+
+In `MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift`, add:
+
+```swift
+var audioLevels: [Float] = []
+```
+
+Add it after the existing `isPaused` property (line 8).
+
+**Step 3: Verify build**
+
+```bash
+xcodebuild build \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: BUILD SUCCEEDED (AudioRecorderService will fail until Task 3, but the protocol + mock should compile)
+
+Note: This step may fail because `AudioRecorderService` doesn't conform yet. If so, proceed to Task 3 before building.
+
+**Step 4: Commit (may combine with Task 3 if build fails)**
+
+```bash
+git add Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift \
+       MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift
+git commit -m "Add audioLevels property to AudioRecording protocol"
+```
+
+---
+
+### Task 3: Implement RMS calculation in AudioRecorderService
+
+**Files:**
+- Modify: `Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift`
+
+**Step 1: Add audioLevels property**
+
+Add after `isPaused` (line 27):
+
+```swift
+public var audioLevels: [Float] = []
+```
+
+**Step 2: Add RMS calculation in the installTap callback**
+
+Replace the existing `installTap` block (lines 67-71) with:
+
+```swift
+let flag = pauseFlag
+inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+    if !flag.value {
+        try? file.write(from: buffer)
+    }
+
+    // Calculate RMS level from audio buffer
+    guard let channelData = buffer.floatChannelData?[0] else { return }
+    let frameLength = Int(buffer.frameLength)
+    var sum: Float = 0
+    for i in 0..<frameLength {
+        let sample = channelData[i]
+        sum += sample * sample
+    }
+    let rms = sqrt(sum / Float(frameLength))
+
+    // Convert to dB and normalize to 0.0-1.0
+    let db = 20 * log10(max(rms, 1e-6))
+    let minDb: Float = -60
+    let maxDb: Float = 0
+    let normalized = max(0, min(1, (db - minDb) / (maxDb - minDb)))
+
+    DispatchQueue.main.async {
+        self?.audioLevels.append(normalized)
+    }
+}
+```
+
+**Step 3: Clear audioLevels in stopRecording()**
+
+In `stopRecording()`, add `audioLevels = []` after `pauseFlag.value = false` (line 97):
+
+```swift
+public func stopRecording() {
+    audioEngine?.inputNode.removeTap(onBus: 0)
+    audioEngine?.stop()
+    audioEngine = nil
+    audioFile = nil
+    isRecording = false
+    isPaused = false
+    pauseFlag.value = false
+    audioLevels = []
+
+    try? AVAudioSession.sharedInstance().setActive(false)
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+xcodebuild build \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: BUILD SUCCEEDED
+
+**Step 5: Commit**
+
+```bash
+git add Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
+git commit -m "Add RMS-based audio level extraction to AudioRecorderService"
+```
+
+---
+
+### Task 4: Forward audioLevels in HomeViewModel
+
+**Files:**
+- Modify: `MindEcho/MindEcho/ViewModels/HomeViewModel.swift`
+
+**Step 1: Add computed property**
+
+In `HomeViewModel`, add after `isRecordingPaused` (line 43):
+
+```swift
+var audioLevels: [Float] { audioRecorder.audioLevels }
+```
+
+**Step 2: Verify build**
+
+```bash
+xcodebuild build \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: BUILD SUCCEEDED
+
+**Step 3: Commit**
+
+```bash
+git add MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+git commit -m "Forward audioLevels from recorder to HomeViewModel"
+```
+
+---
+
+### Task 5: Integrate WaveformLiveCanvas in HomeView
+
+**Files:**
+- Modify: `MindEcho/MindEcho/Views/HomeView.swift`
+
+**Step 1: Add imports**
+
+At the top of `HomeView.swift`, add:
+
+```swift
+import DSWaveformImage
+import DSWaveformImageViews
+```
+
+**Step 2: Add WaveformLiveCanvas between duration and controls**
+
+After the recording duration `Text` (line 32) and before the `HStack` for controls (line 36), insert:
+
+```swift
+// Recording duration (shown when recording)
+if viewModel.isRecording {
+    Text(formatDuration(viewModel.recordingDuration))
+        .font(.system(.largeTitle, design: .monospaced))
+        .accessibilityIdentifier("home.recordingDuration")
+
+    WaveformLiveCanvas(
+        samples: viewModel.audioLevels,
+        configuration: Waveform.Configuration(
+            style: .striped(.init(color: .red, width: 3, spacing: 2)),
+            damping: .init()
+        ),
+        shouldDrawSilencePadding: true
+    )
+    .frame(height: 60)
+    .opacity(viewModel.isRecordingPaused ? 0.5 : 1.0)
+}
+```
+
+This replaces the existing `if viewModel.isRecording` block for duration (lines 29-33). The waveform is placed between the duration text and the control buttons.
+
+**Step 3: Verify build**
+
+```bash
+xcodebuild build \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: BUILD SUCCEEDED
+
+**Step 4: Commit**
+
+```bash
+git add MindEcho/MindEcho/Views/HomeView.swift
+git commit -m "Add live waveform visualization to recording UI"
+```
+
+---
+
+### Task 6: Run existing tests to verify no regressions
+
+**Step 1: Run all tests**
+
+```bash
+xcodebuild test \
+  -project /Users/sy-hash/Projects/mind-echo/MindEcho/MindEcho.xcodeproj \
+  -scheme MindEcho \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+Expected: All existing tests pass.
+
+**Step 2: If tests fail, investigate and fix**
+
+Common issues:
+- `MockAudioRecorderService` missing `audioLevels` (should be fixed in Task 2)
+- Import errors for DSWaveformImage in test targets (add framework search path if needed)

--- a/issue-waveform-feedback.md
+++ b/issue-waveform-feedback.md
@@ -1,0 +1,86 @@
+# 録音中にリアルタイム音声波形フィードバックを追加する
+
+## 概要
+
+iOSのボイスメモアプリの録音画面のように、録音中にリアルタイムの音声波形（waveform）を表示するフィードバック機能を追加する。
+
+## 背景・動機
+
+現在の録音UIでは、録音中の経過時間（MM:SS）のみが表示されており、音声入力の視覚的なフィードバックがない。ボイスメモのような波形表示を追加することで、ユーザーが録音状態を直感的に把握できるようになる。
+
+## 使用ライブラリ
+
+**[DSWaveformImage](https://github.com/dmrschmidt/DSWaveformImage)** (v14.x)
+
+- Swift Package Manager で導入
+- `DSWaveformImage`（コア）+ `DSWaveformImageViews`（SwiftUI ビュー）の2モジュール構成
+- `WaveformLiveCanvas` を使用してリアルタイム波形を描画
+
+### 参考実装
+
+DSWaveformImage のサンプルアプリにある **[RecordingIndicatorView](https://github.com/dmrschmidt/DSWaveformImage/blob/main/Example/DSWaveformImageExample-iOS/SwiftUIExample/RecordingIndicatorView.swift)** を参考にする。
+
+```swift
+// RecordingIndicatorView の主要部分
+struct RecordingIndicatorView: View {
+    let samples: [Float]
+    let duration: TimeInterval
+
+    @State var configuration: Waveform.Configuration = .init(
+        style: .striped(.init(color: .systemGray, width: 3, spacing: 3)),
+        damping: .init()
+    )
+
+    var body: some View {
+        HStack {
+            WaveformLiveCanvas(
+                samples: samples,
+                configuration: configuration,
+                shouldDrawSilencePadding: shouldDrawSilence
+            )
+            Text(timeFormatter.string(from: duration) ?? "00:00")
+            // ...
+        }
+    }
+}
+```
+
+## 実装方針
+
+### 1. DSWaveformImage の導入
+
+- `MindEchoAudio` パッケージの `Package.swift` に DSWaveformImage を SPM 依存として追加
+- または、メインアプリの `MindEcho.xcodeproj` に直接追加
+
+### 2. 音声サンプルデータの取得
+
+- `AudioRecorderService` は既に `AVAudioEngine` + `AVAudioTap` でリアルタイム音声キャプチャを行っている
+- タップコールバックから正規化済み振幅サンプル（`[Float]`、0〜1の範囲）を抽出し、ViewModel へ公開する
+
+### 3. UI の実装
+
+- `HomeView` の録音中表示エリアに `WaveformLiveCanvas` を組み込む
+- DSWaveformImage サンプルの `RecordingIndicatorView` のデザインを参考にする
+  - 波形 + 経過時間 + 録音コントロールの横並びレイアウト
+  - `Waveform.Configuration` の `style` でストライプや色を調整
+
+### 4. 対応すべき状態
+
+| 状態 | 波形表示 |
+|------|---------|
+| 録音中 | ライブ波形を表示 |
+| 一時停止中 | 波形を停止（最後の状態を維持） |
+| 録音停止後 | 波形をクリア / 非表示 |
+
+## 影響範囲
+
+- `Packages/MindEchoAudio/` - 音声サンプルデータの公開
+- `MindEcho/MindEcho/ViewModels/HomeViewModel.swift` - サンプルデータのバインディング
+- `MindEcho/MindEcho/Views/HomeView.swift` - 波形UIの追加
+- `Package.swift` - DSWaveformImage 依存の追加
+
+## 参考リンク
+
+- [DSWaveformImage GitHub](https://github.com/dmrschmidt/DSWaveformImage)
+- [DSWaveformImage - Swift Package Index](https://swiftpackageindex.com/dmrschmidt/DSWaveformImage)
+- [RecordingIndicatorView サンプル](https://github.com/dmrschmidt/DSWaveformImage/blob/main/Example/DSWaveformImageExample-iOS/SwiftUIExample/RecordingIndicatorView.swift)


### PR DESCRIPTION
## Summary

- Add DSWaveformImage v14 as SPM dependency (App Target only)
- Extract RMS audio levels from AVAudioEngine tap callback in `AudioRecorderService`
- Display real-time waveform via `WaveformLiveCanvas` in `HomeView` during recording
- Waveform dims to 50% opacity when paused, clears on stop

## Design

See `docs/plans/2026-02-12-recording-waveform-design.md`

## Test Plan
- [x] All 40 existing tests pass (18 unit + 22 UI)
- [ ] Manual verification on real device: waveform responds to voice input
- [ ] Verify pause dims waveform, resume restores, stop clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)