### PR TITLE
Configure Claude AI workflow with iOS build verification rules

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,15 +39,28 @@ jobs:
             {
               "language": "Japanese"
             }
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
+          allowed_tools: |
+            Bash(xcodebuild build *)
+            Bash(xcodebuild test *)
+            Bash(xcrun simctl *)
+            Read
+            Edit
+            Write
+            Glob
+            Grep
+          custom_instructions: |
+            ## Build Verification Rule
 
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
+            プロダクトコード（Packages/ または MindEcho/MindEcho/ 配下の .swift ファイル）を
+            変更した場合は、必ず以下のコマンドでビルドが通ることを確認すること。
 
-          # Optional: Configure Claude's behavior with CLI arguments
-          # claude_args: |
-          #   --model claude-opus-4-1-20250805
-          #   --max-turns 10
-          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+            ```bash
+            xcodebuild build \
+              -workspace MindEcho.xcworkspace \
+              -scheme MindEcho \
+              -destination 'platform=iOS Simulator,name=iPhone 17'
+            ```
+
+            - ビルドエラーが発生した場合は、エラーを修正して再度ビルドを実行する
+            - テストコードのみの変更、ドキュメントのみの変更の場合はビルド不要
+            - ビルド結果（成功/失敗）をコメントで報告する


### PR DESCRIPTION
## 概要

Claude AI ワークフローの設定を更新し、iOS プロダクトコードの変更時にビルド検証を必須とするルールを追加しました。

## 変更の種類

- [x] ビルド・CI設定の変更

## 変更内容

`.github/workflows/claude.yml` の Claude AI アクション設定を以下の通り更新しました：

1. **許可するツールの明示的な指定**
   - Bash コマンド: `xcodebuild build *`, `xcodebuild test *`, `xcrun simctl *`
   - ファイル操作: Read, Edit, Write, Glob, Grep

2. **カスタム指示の追加（日本語）**
   - プロダクトコード（`Packages/` または `MindEcho/MindEcho/` 配下の `.swift` ファイル）変更時のビルド検証ルール
   - 具体的なビルドコマンド例を提供
   - テストコードやドキュメントのみの変更時は検証不要
   - ビルド結果をコメントで報告することを指示

## 影響範囲

- 対象ファイル: `.github/workflows/claude.yml`
- 対象機能: Claude AI による PR レビュー・コード生成時の動作ルール

## テスト

- [x] ワークフロー設定の構文は有効

## チェックリスト

- [x] YAML 構文が正しいことを確認した
- [x] 既存の CI/CD パイプラインに影響がないことを確認した

## レビュアーへの補足

このワークフロー設定により、Claude AI が iOS プロダクトコードの変更を提案する際に、自動的にビルド検証を実施するようになります。これにより、コンパイルエラーを含む不完全な変更提案を防ぐことができます。

https://claude.ai/code/session_01LRoJFRGiBNP6tJDWoccQab