### PR TITLE
feat: SpeechAnalyzer を使った音声書き起こし機能を実装

### DIFF
--- a/MindEcho/MindEcho.xcodeproj/project.pbxproj
+++ b/MindEcho/MindEcho.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 				INFOPLIST_FILE = MindEcho/Info.plist;
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MindEcho uses the microphone to record your voice memos.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "音声記録の内容をテキストに書き起こすために使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = "(audio)";
@@ -477,6 +478,7 @@
 				INFOPLIST_FILE = MindEcho/Info.plist;
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "MindEcho uses the microphone to record your voice memos.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "音声記録の内容をテキストに書き起こすために使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIBackgroundModes = "(audio)";

--- a/MindEcho/MindEcho/Info.plist
+++ b/MindEcho/MindEcho/Info.plist
@@ -10,5 +10,7 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>音声記録の内容をテキストに書き起こすために使用します。</string>
 </dict>
 </plist>

--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -9,6 +9,7 @@ struct MindEchoApp: App {
     private let modelContainer: ModelContainer
     private let audioRecorder: any AudioRecording
     private let audioPlayer: any AudioPlaying
+    private let transcriptionService: any Transcribing
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -43,6 +44,14 @@ struct MindEchoApp: App {
             audioPlayer = AudioPlayerService()
         }
 
+        if args.contains("--mock-transcription-success") {
+            transcriptionService = MockTranscriptionService(mockResult: .success("モックの書き起こし結果テキストです。"))
+        } else if args.contains("--mock-transcription-failure") {
+            transcriptionService = MockTranscriptionService(mockResult: .failure)
+        } else {
+            transcriptionService = TranscriptionService()
+        }
+
         // Seed data for UI testing
         if isUITesting {
             let context = modelContainer.mainContext
@@ -64,7 +73,8 @@ struct MindEchoApp: App {
                 Tab("今日", systemImage: "mic.circle.fill") {
                     HomeView(
                         modelContext: modelContainer.mainContext,
-                        audioRecorder: audioRecorder
+                        audioRecorder: audioRecorder,
+                        transcriptionService: transcriptionService
                     )
                 }
                 .accessibilityIdentifier("tab.today")

--- a/MindEcho/MindEcho/Mocks/MockTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockTranscriptionService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// UIテスト用の書き起こしサービスモック
+final class MockTranscriptionService: Transcribing {
+    enum MockResult {
+        case success(String)
+        case failure
+    }
+
+    private let mockResult: MockResult
+
+    init(mockResult: MockResult) {
+        self.mockResult = mockResult
+    }
+
+    func transcribe(audioURL: URL) async throws -> String {
+        // シート表示のアニメーションを確認できるよう短いディレイを入れる
+        try await Task.sleep(nanoseconds: 300_000_000) // 0.3s
+        switch mockResult {
+        case .success(let text):
+            return text
+        case .failure:
+            throw TranscriptionError.unavailable
+        }
+    }
+}

--- a/MindEcho/MindEcho/Services/Transcribing.swift
+++ b/MindEcho/MindEcho/Services/Transcribing.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// 音声書き起こしサービスの抽象プロトコル
+protocol Transcribing {
+    func transcribe(audioURL: URL) async throws -> String
+}

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -24,7 +24,7 @@ enum TranscriptionError: LocalizedError {
 // MARK: - TranscriptionService
 
 /// SpeechAnalyzer（iOS 26+）を使ったオンデバイス音声書き起こしサービス
-final class TranscriptionService {
+final class TranscriptionService: Transcribing {
 
     // MARK: Authorization
 

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -1,0 +1,82 @@
+import AVFoundation
+import Foundation
+import Speech
+
+// MARK: - Error
+
+enum TranscriptionError: LocalizedError {
+    case notAuthorized
+    case unavailable
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "音声認識の権限がありません。設定アプリから権限を許可してください。"
+        case .unavailable:
+            return "音声認識が現在利用できません。"
+        case .failed(let message):
+            return "書き起こしに失敗しました: \(message)"
+        }
+    }
+}
+
+// MARK: - TranscriptionService
+
+/// SpeechAnalyzer（iOS 26+）を使ったオンデバイス音声書き起こしサービス
+final class TranscriptionService {
+
+    // MARK: Authorization
+
+    static func requestAuthorization() async -> Bool {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    // MARK: Transcription
+
+    /// 指定した音声ファイルを書き起こす
+    /// - Parameter audioURL: 書き起こし対象の音声ファイル URL
+    /// - Returns: 書き起こし結果のテキスト
+    func transcribe(audioURL: URL) async throws -> String {
+        guard await Self.requestAuthorization() else {
+            throw TranscriptionError.notAuthorized
+        }
+
+        return try await transcribeWithSpeechAnalyzer(audioURL: audioURL)
+    }
+
+    // MARK: - Private
+
+    private func transcribeWithSpeechAnalyzer(audioURL: URL) async throws -> String {
+        // SpeechAnalyzer (iOS 26+) を使用してオンデバイスで書き起こす
+        let analyzer = SpeechAnalyzer()
+
+        // 音声ファイルを AVAudioFile として開く
+        let audioFile = try AVAudioFile(forReading: audioURL)
+        let format = audioFile.processingFormat
+        let frameCount = AVAudioFrameCount(audioFile.length)
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw TranscriptionError.failed("音声バッファの作成に失敗しました")
+        }
+        try audioFile.read(into: buffer)
+
+        // バッファを AsyncStream に変換して SpeechAnalyzer に渡す
+        let (stream, continuation) = AsyncStream<AVAudioPCMBuffer>.makeStream()
+        continuation.yield(buffer)
+        continuation.finish()
+
+        var finalText = ""
+        for try await result in analyzer.results(for: stream, audioFormat: format) {
+            if let transcription = result.speechRecognitionResult?.bestTranscription {
+                finalText = transcription.formattedString
+            }
+        }
+
+        return finalText
+    }
+}

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -53,7 +53,7 @@ final class TranscriptionService {
 
     private func transcribeWithSpeechAnalyzer(audioURL: URL) async throws -> String {
         // SpeechAnalyzer (iOS 26+) を使用してオンデバイスで書き起こす
-        let analyzer = SpeechAnalyzer()
+        let analyzer = SpeechAnalyzer(modules: [SpeechTranscriber()])
 
         // 音声ファイルを AVAudioFile として開く
         let audioFile = try AVAudioFile(forReading: audioURL)

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -99,6 +99,14 @@ struct HomeView: View {
                                         Text(formatDuration(recording.duration))
                                             .foregroundStyle(.secondary)
                                         Spacer()
+                                        Button {
+                                            viewModel.startTranscription(for: recording)
+                                        } label: {
+                                            Image(systemName: "text.bubble")
+                                                .foregroundStyle(.blue)
+                                        }
+                                        .accessibilityIdentifier("home.transcribeButton.\(recording.sequenceNumber)")
+                                        .padding(.trailing, 8)
                                         Image(systemName: viewModel.playingRecordingId == recording.id && viewModel.isPlaying ? "pause.fill" : "play.fill")
                                     }
                                     .padding(.vertical, 12)
@@ -110,8 +118,7 @@ struct HomeView: View {
                                             viewModel.playRecording(recording)
                                         }
                                     }
-                                    .accessibilityElement(children: .combine)
-                                    .accessibilityAddTraits(.isButton)
+                                    .accessibilityElement(children: .contain)
                                     .accessibilityIdentifier("home.recordingRow.\(recording.sequenceNumber)")
 
                                     if recording.id != entry.sortedRecordings.last?.id {
@@ -145,6 +152,16 @@ struct HomeView: View {
                     }
                 )
                 .accessibilityIdentifier("home.textEditorSheet")
+            }
+            .sheet(isPresented: $viewModel.showTranscriptionSheet) {
+                TranscriptionSheet(
+                    sequenceNumber: viewModel.transcriptionTargetRecording?.sequenceNumber ?? 0,
+                    state: viewModel.transcriptionState,
+                    onDismiss: {
+                        viewModel.dismissTranscription()
+                    }
+                )
+                .accessibilityIdentifier("home.transcriptionSheet")
             }
         }
     }

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -10,10 +10,15 @@ struct HomeView: View {
     @State private var showTextEditor = false
     @State private var editingText = ""
 
-    init(modelContext: ModelContext, audioRecorder: any AudioRecording) {
+    init(
+        modelContext: ModelContext,
+        audioRecorder: any AudioRecording,
+        transcriptionService: any Transcribing = TranscriptionService()
+    ) {
         _viewModel = State(initialValue: HomeViewModel(
             modelContext: modelContext,
-            audioRecorder: audioRecorder
+            audioRecorder: audioRecorder,
+            transcriptionService: transcriptionService
         ))
     }
 

--- a/MindEcho/MindEcho/Views/TranscriptionSheet.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionSheet.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+// MARK: - Transcription State
+
+enum TranscriptionState {
+    case idle
+    case loading
+    case success(String)
+    case failure(String)
+}
+
+// MARK: - TranscriptionSheet
+
+struct TranscriptionSheet: View {
+    let sequenceNumber: Int
+    let state: TranscriptionState
+    var onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch state {
+                case .idle:
+                    idleView
+                case .loading:
+                    loadingView
+                case .success(let text):
+                    successView(text: text)
+                case .failure(let message):
+                    failureView(message: message)
+                }
+            }
+            .navigationTitle("書き起こし #\(sequenceNumber)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("閉じる", action: onDismiss)
+                        .accessibilityIdentifier("transcription.closeButton")
+                }
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var idleView: some View {
+        ContentUnavailableView(
+            "書き起こし準備中",
+            systemImage: "waveform",
+            description: Text("まもなく開始します")
+        )
+        .accessibilityIdentifier("transcription.idleView")
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("書き起こし中...")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("transcription.loadingView")
+    }
+
+    private func successView(text: String) -> some View {
+        ScrollView {
+            Text(text)
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .textSelection(.enabled)
+        }
+        .accessibilityIdentifier("transcription.resultText")
+    }
+
+    private func failureView(message: String) -> some View {
+        ContentUnavailableView(
+            "書き起こし失敗",
+            systemImage: "exclamationmark.triangle",
+            description: Text(message)
+        )
+        .accessibilityIdentifier("transcription.errorView")
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/HomeTranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HomeTranscriptionUITests.swift
@@ -1,0 +1,130 @@
+import XCTest
+
+final class HomeTranscriptionUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = [
+            "--uitesting",
+            "--mock-recorder",
+            "--seed-today-with-recordings",
+        ]
+        addUIInterruptionMonitor(withDescription: "Speech Recognition Permission") { alert in
+            let allowButton = alert.buttons["Allow"]
+            if allowButton.exists {
+                allowButton.tap()
+                return true
+            }
+            let allowButtonJa = alert.buttons["許可"]
+            if allowButtonJa.exists {
+                allowButtonJa.tap()
+                return true
+            }
+            return false
+        }
+    }
+
+    // MARK: - Tests
+
+    /// 録音セルごとに書き起こしボタン（text.bubble）が表示される
+    @MainActor
+    func testTranscribeButton_appearsForEachRecording() throws {
+        app.launchArguments.append("--mock-transcription-success")
+        app.launch()
+
+        let recordingsList = app.descendants(matching: .any)["home.recordingsList"]
+        XCTAssertTrue(recordingsList.waitForExistence(timeout: 5))
+
+        // シードデータは3件の録音を含む
+        for n in 1...3 {
+            let transcribeBtn = app.buttons["home.transcribeButton.\(n)"]
+            XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5), "録音 #\(n) の書き起こしボタンが見つかりません")
+        }
+    }
+
+    /// 書き起こしボタンをタップすると TranscriptionSheet が表示される
+    @MainActor
+    func testTapTranscribeButton_opensTranscriptionSheet() throws {
+        app.launchArguments.append("--mock-transcription-success")
+        app.launch()
+
+        let transcribeBtn = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        transcribeBtn.tap()
+        app.tap()
+
+        let sheet = app.otherElements["home.transcriptionSheet"]
+        XCTAssertTrue(sheet.waitForExistence(timeout: 5))
+    }
+
+    /// シートのナビゲーションタイトルに録音の連番が含まれる
+    @MainActor
+    func testTranscriptionSheet_showsSequenceNumberInTitle() throws {
+        app.launchArguments.append("--mock-transcription-success")
+        app.launch()
+
+        let transcribeBtn = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        transcribeBtn.tap()
+        app.tap()
+
+        // NavigationTitle "書き起こし #1" が表示される
+        let titleLabel = app.staticTexts["書き起こし #1"]
+        XCTAssertTrue(titleLabel.waitForExistence(timeout: 5))
+    }
+
+    /// 成功時に書き起こし結果テキストが表示される
+    @MainActor
+    func testTranscriptionSuccess_showsResultText() throws {
+        app.launchArguments.append("--mock-transcription-success")
+        app.launch()
+
+        let transcribeBtn = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        transcribeBtn.tap()
+        app.tap()
+
+        // 成功後に resultText ビューが表示される（モックは 0.3s 後に成功を返す）
+        let resultText = app.scrollViews["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 10))
+    }
+
+    /// 失敗時にエラービューが表示される
+    @MainActor
+    func testTranscriptionFailure_showsErrorView() throws {
+        app.launchArguments.append("--mock-transcription-failure")
+        app.launch()
+
+        let transcribeBtn = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        transcribeBtn.tap()
+        app.tap()
+
+        // 失敗後にエラービューが表示される
+        let errorView = app.otherElements["transcription.errorView"]
+        XCTAssertTrue(errorView.waitForExistence(timeout: 10))
+    }
+
+    /// 閉じるボタンをタップするとシートが閉じる
+    @MainActor
+    func testTranscriptionSheet_closeButton_dismissesSheet() throws {
+        app.launchArguments.append("--mock-transcription-success")
+        app.launch()
+
+        let transcribeBtn = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        transcribeBtn.tap()
+        app.tap()
+
+        let closeBtn = app.buttons["transcription.closeButton"]
+        XCTAssertTrue(closeBtn.waitForExistence(timeout: 5))
+        closeBtn.tap()
+
+        // シートが閉じ、書き起こしボタンが再び表示される
+        XCTAssertTrue(transcribeBtn.waitForExistence(timeout: 5))
+        let sheet = app.otherElements["home.transcriptionSheet"]
+        XCTAssertFalse(sheet.exists)
+    }
+}


### PR DESCRIPTION
- TranscriptionService: SpeechAnalyzer（iOS 26+）ラッパーを追加
  - AVAudioFile からバッファを読み込み AsyncStream 経由で SpeechAnalyzer に渡す
  - SFSpeechRecognizer.requestAuthorization で権限リクエスト
- TranscriptionSheet: 書き起こし結果表示モーダルを追加
  - idle / loading / success / failure の状態遷移に対応
- HomeView: 各録音セルに書き起こしボタン（text.bubble）を追加
  - ボタン押下で TranscriptionSheet をシート表示
- HomeViewModel: 書き起こし状態管理を追加
  - transcriptionTargetRecording, transcriptionState, showTranscriptionSheet
  - startTranscription(for:) / dismissTranscription() メソッド
- Info.plist / xcodeproj: NSSpeechRecognitionUsageDescription を追加

Closes #21

## 概要

<!-- このPRで何を変更したか簡潔に記述してください -->

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] ビルド・CI設定の変更
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## 影響範囲

<!-- この変更が影響するファイル・画面・機能を記述してください -->

- 対象画面:
- 対象機能:

## スクリーンショット / 動画

<!-- UI変更がある場合、変更前後のスクリーンショットや動画を添付してください -->

| 変更前 | 変更後 |
|--------|--------|
|        |        |

## テスト

- [ ] ユニットテストを追加・更新した
- [ ] UIテストを追加・更新した
- [ ] シミュレータで動作確認した
- [ ] 実機で動作確認した

## チェックリスト

- [ ] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [ ] 不要なデバッグコード・print文を削除した
- [ ] 既存の機能にデグレがないことを確認した

## 関連Issue

<!-- 関連するIssue番号があればリンクしてください (例: #123) -->

## レビュアーへの補足

<!-- レビュー時に特に見てほしいポイントや注意点があれば記述してください -->
