### PR TITLE
Refactor Claude workflow auth to use GitHub event sender check

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.login == 'sy-hash' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: macos-26
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_users: "sy-hash"
           settings: |
             {
               "language": "Japanese"


### PR DESCRIPTION
## 概要

Claude Code Actionワークフローの認証方式をリファクタリングしました。ユーザー制限をワークフロー条件式に統合し、アクション設定から`allowed_users`パラメータを削除しました。

## 変更の種類

- [x] リファクタリング
- [x] ビルド・CI設定の変更

## 変更内容

`.github/workflows/claude.yml`を以下のように修正しました：

1. **ワークフロー実行条件の強化**
   - `github.event.sender.login == 'sy-hash'`チェックをジョブ条件の最上位に追加
   - 既存の`@claude`メンション検出ロジックをネストして保持

2. **アクション設定の簡素化**
   - Claude Code Actionから`allowed_users: "sy-hash"`パラメータを削除
   - ユーザー認証をワークフロー条件レベルで一元管理

この変更により、ユーザー制限がワークフロー実行時点で評価されるため、不要なアクション実行を防ぎ、より効率的な認証フローになります。

## 影響範囲

- 対象ファイル: `.github/workflows/claude.yml`
- 対象機能: Claude Code Actionの実行制御

## テスト

- [x] CI設定の構文は有効（GitHub Actionsで検証可能）

## チェックリスト

- [x] ワークフロー構文が正しいことを確認した
- [x] 既存の`@claude`メンション検出機能が保持されていることを確認した
- [x] ユーザー認証ロジックが正しく統合されていることを確認した

## レビュアーへの補足

この変更は認証メカニズムの移動であり、機能的な動作は変わりません。`sy-hash`ユーザーのみがワークフローをトリガーできるという制限は維持されます。

https://claude.ai/code/session_018YQAJe9hZVNHzgLeycYL6m