### PR TITLE
feat: 録音UIをモーダルに移行し、書き起こし結果を表示する

### DIFF
--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -6,12 +6,25 @@ import SwiftData
 
 @Observable
 class HomeViewModel {
+    enum TranscriptionState: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+    }
+
     var recordingDuration: TimeInterval = 0
     var playingRecordingId: UUID?
     var isPlaying = false
     var playbackProgress: Double = 0
     var todayEntry: JournalEntry?
     var errorMessage: String?
+    private(set) var transcriptionState: TranscriptionState = .idle
+
+    @ObservationIgnored
+    var transcribe: (URL, Locale) async throws -> String = { url, locale in
+        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale)
+    }
 
     private let modelContext: ModelContext
     private var audioRecorder: any AudioRecording
@@ -21,6 +34,7 @@ class HomeViewModel {
     private var accumulatedDuration: TimeInterval = 0
     private var currentRecordingFileName: String?
     private var currentRecordingStartedAt: Date?
+    private var lastRecordedFileName: String?
 
     init(
         modelContext: ModelContext,
@@ -46,6 +60,8 @@ class HomeViewModel {
     // MARK: - Recording
 
     func startRecording() {
+        transcriptionState = .idle
+        lastRecordedFileName = nil
         do {
             try FilePathManager.ensureDirectoryExists(FilePathManager.recordingsDirectory)
             let url = FilePathManager.newRecordingURL()
@@ -88,6 +104,7 @@ class HomeViewModel {
 
         // Save recording to SwiftData
         guard let fileName = currentRecordingFileName else { return }
+        lastRecordedFileName = fileName
         let today = DateHelper.logicalDate()
         let entry = getOrCreateTodayEntry(for: today)
         let nextSeq = (entry.recordings.map(\.sequenceNumber).max() ?? 0) + 1
@@ -107,6 +124,25 @@ class HomeViewModel {
         recordingDuration = 0
         accumulatedDuration = 0
         recordingStartTime = nil
+    }
+
+    // MARK: - Transcription
+
+    func startTranscription() async {
+        guard let fileName = lastRecordedFileName else { return }
+        let url = FilePathManager.recordingsDirectory.appendingPathComponent(fileName)
+        transcriptionState = .loading
+        do {
+            let text = try await transcribe(url, Locale(identifier: "ja-JP"))
+            transcriptionState = text.isEmpty ? .failure("書き起こし結果が空でした。") : .success(text)
+        } catch {
+            transcriptionState = .failure("書き起こしに失敗しました: \(error.localizedDescription)")
+        }
+    }
+
+    func resetTranscriptionState() {
+        transcriptionState = .idle
+        lastRecordedFileName = nil
     }
 
     // MARK: - Playback

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -1,5 +1,3 @@
-import DSWaveformImage
-import DSWaveformImageViews
 import MindEchoAudio
 import MindEchoCore
 import SwiftData
@@ -8,6 +6,7 @@ import SwiftUI
 struct HomeView: View {
     @State private var viewModel: HomeViewModel
     @State private var transcriptionTargetRecording: Recording?
+    @State private var isRecordingModalPresented = false
 
     init(modelContext: ModelContext, audioRecorder: any AudioRecording) {
         _viewModel = State(initialValue: HomeViewModel(
@@ -28,56 +27,15 @@ struct HomeView: View {
 
                         Spacer()
 
-                        // Recording duration (shown when recording)
-                        if viewModel.isRecording {
-                            Text(formatDuration(viewModel.recordingDuration))
-                                .font(.system(.largeTitle, design: .monospaced))
-                                .accessibilityIdentifier("home.recordingDuration")
-
-                            WaveformLiveCanvas(
-                                samples: viewModel.audioLevels,
-                                configuration: Waveform.Configuration(
-                                    style: .striped(.init(color: .red, width: 3, spacing: 3)),
-                                    damping: .init()
-                                ),
-                                shouldDrawSilencePadding: false
-                            )
-                            .frame(height: 80)
-                            .accessibilityIdentifier("home.waveform")
+                        // Recording start button
+                        Button {
+                            isRecordingModalPresented = true
+                        } label: {
+                            Image(systemName: "mic.circle.fill")
+                                .font(.system(size: 70))
+                                .foregroundStyle(.red)
                         }
-
-                        // Recording controls
-                        HStack(spacing: 30) {
-                            if viewModel.isRecording {
-                                if viewModel.isRecordingPaused {
-                                    Button { viewModel.resumeRecording() } label: {
-                                        Image(systemName: "play.circle.fill")
-                                            .font(.system(size: 50))
-                                    }
-                                    .accessibilityIdentifier("home.resumeButton")
-                                } else {
-                                    Button { viewModel.pauseRecording() } label: {
-                                        Image(systemName: "pause.circle.fill")
-                                            .font(.system(size: 50))
-                                    }
-                                    .accessibilityIdentifier("home.pauseButton")
-                                }
-
-                                Button { viewModel.stopRecording() } label: {
-                                    Image(systemName: "stop.circle.fill")
-                                        .font(.system(size: 50))
-                                        .foregroundStyle(.red)
-                                }
-                                .accessibilityIdentifier("home.stopButton")
-                            } else {
-                                Button { viewModel.startRecording() } label: {
-                                    Image(systemName: "mic.circle.fill")
-                                        .font(.system(size: 70))
-                                        .foregroundStyle(.red)
-                                }
-                                .accessibilityIdentifier("home.recordButton")
-                            }
-                        }
+                        .accessibilityIdentifier("home.recordButton")
 
                         // Today's recordings list
                         if let entry = viewModel.todayEntry, !entry.recordings.isEmpty {
@@ -128,6 +86,15 @@ struct HomeView: View {
             .navigationTitle("今日")
             .onAppear {
                 viewModel.fetchTodayEntry()
+            }
+            .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
+                if viewModel.isRecording {
+                    viewModel.stopRecording()
+                }
+                viewModel.resetTranscriptionState()
+                viewModel.fetchTodayEntry()
+            }) {
+                RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
                 TranscriptionView(recording: recording)

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -17,58 +17,57 @@ struct HomeView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                ScrollView {
-                    VStack(spacing: 20) {
-                        // Date display
-                        Text(DateHelper.displayString(for: DateHelper.today()))
-                            .font(.title2)
-                            .accessibilityIdentifier("home.dateLabel")
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Date display
+                    Text(DateHelper.displayString(for: DateHelper.today()))
+                        .font(.title2)
+                        .accessibilityIdentifier("home.dateLabel")
 
-                        // Today's recordings list
-                        if let entry = viewModel.todayEntry, !entry.recordings.isEmpty {
-                            VStack(spacing: 0) {
-                                ForEach(entry.sortedRecordings) { recording in
-                                    HStack {
-                                        Text("#\(recording.sequenceNumber)")
-                                            .font(.headline)
-                                        Text(formatDuration(recording.duration))
-                                            .foregroundStyle(.secondary)
-                                        Spacer()
-                                        Button {
-                                            transcriptionTargetRecording = recording
-                                        } label: {
-                                            Image(systemName: "doc.text")
-                                        }
-                                        .accessibilityIdentifier("home.transcribeButton.\(recording.sequenceNumber)")
-                                        Image(systemName: viewModel.playingRecordingId == recording.id && viewModel.isPlaying ? "pause.fill" : "play.fill")
+                    // Today's recordings list
+                    if let entry = viewModel.todayEntry, !entry.recordings.isEmpty {
+                        VStack(spacing: 0) {
+                            ForEach(entry.sortedRecordings) { recording in
+                                HStack {
+                                    Text("#\(recording.sequenceNumber)")
+                                        .font(.headline)
+                                    Text(formatDuration(recording.duration))
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Button {
+                                        transcriptionTargetRecording = recording
+                                    } label: {
+                                        Image(systemName: "doc.text")
                                     }
-                                    .padding(.vertical, 12)
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
-                                        if viewModel.playingRecordingId == recording.id && viewModel.isPlaying {
-                                            viewModel.pausePlayback()
-                                        } else {
-                                            viewModel.playRecording(recording)
-                                        }
-                                    }
-                                    .accessibilityElement(children: .combine)
-                                    .accessibilityAddTraits(.isButton)
-                                    .accessibilityIdentifier("home.recordingRow.\(recording.sequenceNumber)")
-
-                                    if recording.id != entry.sortedRecordings.last?.id {
-                                        Divider()
+                                    .accessibilityIdentifier("home.transcribeButton.\(recording.sequenceNumber)")
+                                    Image(systemName: viewModel.playingRecordingId == recording.id && viewModel.isPlaying ? "pause.fill" : "play.fill")
+                                }
+                                .padding(.vertical, 12)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if viewModel.playingRecordingId == recording.id && viewModel.isPlaying {
+                                        viewModel.pausePlayback()
+                                    } else {
+                                        viewModel.playRecording(recording)
                                     }
                                 }
-                            }
-                            .accessibilityElement(children: .contain)
-                            .accessibilityIdentifier("home.recordingsList")
-                        }
-                    }
-                    .padding()
-                }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityAddTraits(.isButton)
+                                .accessibilityIdentifier("home.recordingRow.\(recording.sequenceNumber)")
 
-                // Recording start button - fixed at bottom for stable accessibility
+                                if recording.id != entry.sortedRecordings.last?.id {
+                                    Divider()
+                                }
+                            }
+                        }
+                        .accessibilityElement(children: .contain)
+                        .accessibilityIdentifier("home.recordingsList")
+                    }
+                }
+                .padding()
+            }
+            .safeAreaInset(edge: .bottom) {
+                // Recording start button - pinned to safe area bottom for stable accessibility
                 Button {
                     isRecordingModalPresented = true
                 } label: {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -66,18 +66,6 @@ struct HomeView: View {
                 }
                 .padding()
             }
-            .safeAreaInset(edge: .bottom) {
-                // Recording start button - pinned to safe area bottom for stable accessibility
-                Button {
-                    isRecordingModalPresented = true
-                } label: {
-                    Image(systemName: "mic.circle.fill")
-                        .font(.system(size: 70))
-                        .foregroundStyle(.red)
-                }
-                .accessibilityIdentifier("home.recordButton")
-                .padding(.vertical)
-            }
             .navigationTitle("今日")
             .onAppear {
                 viewModel.fetchTodayEntry()
@@ -95,6 +83,19 @@ struct HomeView: View {
                 TranscriptionView(recording: recording)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
+        }
+        // Recording start button - pinned outside NavigationStack for stable accessibility frame
+        // regardless of ScrollView content updates
+        .safeAreaInset(edge: .bottom) {
+            Button {
+                isRecordingModalPresented = true
+            } label: {
+                Image(systemName: "mic.circle.fill")
+                    .font(.system(size: 70))
+                    .foregroundStyle(.red)
+            }
+            .accessibilityIdentifier("home.recordButton")
+            .padding(.vertical)
         }
     }
 

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -17,25 +17,13 @@ struct HomeView: View {
 
     var body: some View {
         NavigationStack {
-            GeometryReader { geometry in
+            VStack(spacing: 0) {
                 ScrollView {
                     VStack(spacing: 20) {
                         // Date display
                         Text(DateHelper.displayString(for: DateHelper.today()))
                             .font(.title2)
                             .accessibilityIdentifier("home.dateLabel")
-
-                        Spacer()
-
-                        // Recording start button
-                        Button {
-                            isRecordingModalPresented = true
-                        } label: {
-                            Image(systemName: "mic.circle.fill")
-                                .font(.system(size: 70))
-                                .foregroundStyle(.red)
-                        }
-                        .accessibilityIdentifier("home.recordButton")
 
                         // Today's recordings list
                         if let entry = viewModel.todayEntry, !entry.recordings.isEmpty {
@@ -75,13 +63,21 @@ struct HomeView: View {
                             }
                             .accessibilityElement(children: .contain)
                             .accessibilityIdentifier("home.recordingsList")
-                        } else {
-                            Spacer()
                         }
                     }
                     .padding()
-                    .frame(minHeight: geometry.size.height)
                 }
+
+                // Recording start button - fixed at bottom for stable accessibility
+                Button {
+                    isRecordingModalPresented = true
+                } label: {
+                    Image(systemName: "mic.circle.fill")
+                        .font(.system(size: 70))
+                        .foregroundStyle(.red)
+                }
+                .accessibilityIdentifier("home.recordButton")
+                .padding(.vertical)
             }
             .navigationTitle("今日")
             .onAppear {

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -1,0 +1,118 @@
+import DSWaveformImage
+import DSWaveformImageViews
+import SwiftUI
+
+struct RecordingModalView: View {
+    var viewModel: HomeViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                if viewModel.isRecording {
+                    // Recording duration
+                    Text(formatDuration(viewModel.recordingDuration))
+                        .font(.system(.largeTitle, design: .monospaced))
+                        .accessibilityIdentifier("recording.duration")
+
+                    // Waveform
+                    WaveformLiveCanvas(
+                        samples: viewModel.audioLevels,
+                        configuration: Waveform.Configuration(
+                            style: .striped(.init(color: .red, width: 3, spacing: 3)),
+                            damping: .init()
+                        ),
+                        shouldDrawSilencePadding: false
+                    )
+                    .frame(height: 80)
+                    .accessibilityIdentifier("recording.waveform")
+
+                    // Pause/Resume + Stop buttons
+                    HStack(spacing: 30) {
+                        if viewModel.isRecordingPaused {
+                            Button {
+                                viewModel.resumeRecording()
+                            } label: {
+                                Image(systemName: "play.circle.fill")
+                                    .font(.system(size: 50))
+                            }
+                            .accessibilityIdentifier("recording.resumeButton")
+                        } else {
+                            Button {
+                                viewModel.pauseRecording()
+                            } label: {
+                                Image(systemName: "pause.circle.fill")
+                                    .font(.system(size: 50))
+                            }
+                            .accessibilityIdentifier("recording.pauseButton")
+                        }
+
+                        Button {
+                            viewModel.stopRecording()
+                            Task {
+                                await viewModel.startTranscription()
+                            }
+                        } label: {
+                            Image(systemName: "stop.circle.fill")
+                                .font(.system(size: 50))
+                                .foregroundStyle(.red)
+                        }
+                        .accessibilityIdentifier("recording.stopButton")
+                    }
+                } else {
+                    // Transcription result area
+                    switch viewModel.transcriptionState {
+                    case .idle:
+                        EmptyView()
+                    case .loading:
+                        ProgressView("書き起こし中...")
+                            .padding()
+                    case .success(let text):
+                        ScrollView {
+                            Text(text)
+                                .padding()
+                                .textSelection(.enabled)
+                                .accessibilityIdentifier("recording.transcriptionResult")
+                        }
+                    case .failure(let message):
+                        VStack(spacing: 12) {
+                            Label("書き起こし失敗", systemImage: "exclamationmark.triangle")
+                                .font(.headline)
+                            Text(message)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding()
+                        .accessibilityIdentifier("recording.transcriptionResult")
+                    }
+
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.top)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("録音中")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .onAppear {
+            if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
+                viewModel.transcribe = { _, _ in
+                    try await Task.sleep(for: .milliseconds(500))
+                    return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
+                }
+            }
+            viewModel.startRecording()
+        }
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
@@ -6,7 +6,7 @@ final class HomeRecordingUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting", "--mock-recorder"]
+        app.launchArguments = ["--uitesting", "--mock-recorder", "--mock-transcription"]
         app.resetAuthorizationStatus(for: .microphone)
         addUIInterruptionMonitor(withDescription: "Microphone Permission") { alert in
             let allowButton = alert.buttons["Allow"]
@@ -25,89 +25,60 @@ final class HomeRecordingUITests: XCTestCase {
     }
 
     @MainActor
-    func testInitialState_showsRecordButtonOnly() throws {
+    func testRecordingModalFlow() throws {
         app.launch()
-        let recordBtn = app.buttons["home.recordButton"]
-        XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
-        XCTAssertFalse(app.buttons["home.pauseButton"].exists)
-        XCTAssertFalse(app.buttons["home.stopButton"].exists)
-        XCTAssertFalse(app.buttons["home.resumeButton"].exists)
-    }
 
-    @MainActor
-    func testStartRecording_showsPauseAndStopButtons() throws {
-        app.launch()
-        app.buttons["home.recordButton"].tap()
-        // Trigger interrupt monitor for permission alert
-        app.tap()
-
-        let pauseBtn = app.buttons["home.pauseButton"]
-        XCTAssertTrue(pauseBtn.waitForExistence(timeout: 10))
-        XCTAssertTrue(app.buttons["home.stopButton"].exists)
-        XCTAssertFalse(app.buttons["home.recordButton"].exists)
-    }
-
-    @MainActor
-    func testPauseRecording_showsResumeButton() throws {
-        app.launch()
-        app.buttons["home.recordButton"].tap()
-        app.tap()
-
-        let pauseBtn = app.buttons["home.pauseButton"]
-        XCTAssertTrue(pauseBtn.waitForExistence(timeout: 10))
-        pauseBtn.tap()
-
-        let resumeBtn = app.buttons["home.resumeButton"]
-        XCTAssertTrue(resumeBtn.waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["home.stopButton"].exists)
-        XCTAssertFalse(app.buttons["home.pauseButton"].exists)
-    }
-
-    @MainActor
-    func testStopRecording_addsRecordingToList() throws {
-        app.launch()
-        app.buttons["home.recordButton"].tap()
-        app.tap()
-
-        let stopBtn = app.buttons["home.stopButton"]
-        XCTAssertTrue(stopBtn.waitForExistence(timeout: 10))
-        stopBtn.tap()
-
-        // After stopping, record button should reappear
+        // 1. Assert home.recordButton exists
         let recordBtn = app.buttons["home.recordButton"]
         XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
 
-        // A recording should be added to the list
-        let recordingRow = app.descendants(matching: .any)["home.recordingRow.1"]
-        XCTAssertTrue(recordingRow.waitForExistence(timeout: 5))
-    }
-
-    @MainActor
-    func testMultipleRecordings_appearInOrder() throws {
-        app.launch()
-
-        // First recording
-        app.buttons["home.recordButton"].tap()
-        app.tap()
-        let stopBtn1 = app.buttons["home.stopButton"]
-        XCTAssertTrue(stopBtn1.waitForExistence(timeout: 10))
-        stopBtn1.tap()
-
-        // Wait for record button to reappear
-        let recordBtn = app.buttons["home.recordButton"]
-        XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
-
-        // Second recording
+        // 2. Tap home.recordButton → modal opens + recording starts
         recordBtn.tap()
-        let stopBtn2 = app.buttons["home.stopButton"]
-        XCTAssertTrue(stopBtn2.waitForExistence(timeout: 5))
-        stopBtn2.tap()
+        // Trigger interrupt monitor for microphone permission alert
+        app.tap()
 
-        // Both recordings should be in the list
-        XCTAssertTrue(app.buttons["home.recordButton"].waitForExistence(timeout: 5))
-        let row1 = app.descendants(matching: .any)["home.recordingRow.1"]
-        let row2 = app.descendants(matching: .any)["home.recordingRow.2"]
-        XCTAssertTrue(row1.waitForExistence(timeout: 5))
-        XCTAssertTrue(row2.waitForExistence(timeout: 5))
+        // 3. Assert modal recording elements exist
+        XCTAssertTrue(app.staticTexts["recording.duration"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.otherElements["recording.waveform"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.pauseButton"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 5))
+
+        // 4. Tap pause
+        app.buttons["recording.pauseButton"].tap()
+        XCTAssertTrue(app.buttons["recording.resumeButton"].waitForExistence(timeout: 5))
+
+        // 5. Tap resume
+        app.buttons["recording.resumeButton"].tap()
+        XCTAssertTrue(app.buttons["recording.pauseButton"].waitForExistence(timeout: 5))
+
+        // 6. Tap stop → transcription starts
+        app.buttons["recording.stopButton"].tap()
+
+        // 7. Assert transcription result is shown
+        let transcriptionResult = app.staticTexts["recording.transcriptionResult"]
+        XCTAssertTrue(transcriptionResult.waitForExistence(timeout: 10))
+
+        // 8. Dismiss modal by swiping down
+        app.swipeDown()
+
+        // 9. Assert first recording row exists in home list
+        let recordingRow1 = app.descendants(matching: .any)["home.recordingRow.1"]
+        XCTAssertTrue(recordingRow1.waitForExistence(timeout: 5))
+
+        // 10. Second recording
+        XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
+        recordBtn.tap()
+
+        XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 10))
+        app.buttons["recording.stopButton"].tap()
+
+        XCTAssertTrue(app.staticTexts["recording.transcriptionResult"].waitForExistence(timeout: 10))
+
+        // 11. Dismiss second modal
+        app.swipeDown()
+
+        // 12. Assert both recording rows exist
+        XCTAssertTrue(app.descendants(matching: .any)["home.recordingRow.1"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["home.recordingRow.2"].waitForExistence(timeout: 5))
     }
 }

--- a/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
@@ -65,8 +65,13 @@ final class HomeRecordingUITests: XCTestCase {
         let recordingRow1 = app.descendants(matching: .any)["home.recordingRow.1"]
         XCTAssertTrue(recordingRow1.waitForExistence(timeout: 5))
 
-        // 10. Second recording
+        // 10. Second recording - wait for button to be hittable after layout update from recording row being added
         XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
+        let hittableExpectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "isHittable == true"),
+            object: recordBtn
+        )
+        wait(for: [hittableExpectation], timeout: 5.0)
         recordBtn.tap()
 
         XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 10))

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・19テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・15テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -37,14 +37,26 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 
 - `home.dateLabel`
 - `home.recordButton`
-- `home.pauseButton`
-- `home.resumeButton`
-- `home.stopButton`
-- `home.recordingDuration`
 - `home.recordingsList`
 - `home.recordingRow.{n}`
 - `home.transcribeButton.{n}`
 - `home.transcriptionSheet`
+
+### RecordingModalView
+
+録音中はモーダルシートとして表示される。録音中と書き起こし後で表示要素が切り替わる。
+
+**録音中（`viewModel.isRecording == true`）**
+
+- `recording.duration` — 録音時間（モノスペースフォント）
+- `recording.waveform` — リアルタイム波形表示
+- `recording.pauseButton` — 一時停止ボタン（録音中のみ表示）
+- `recording.resumeButton` — 再開ボタン（一時停止中のみ表示）
+- `recording.stopButton` — 停止ボタン
+
+**書き起こし後（`viewModel.isRecording == false`）**
+
+- `recording.transcriptionResult` — 書き起こし結果テキスト（成功・失敗どちらも同じ識別子）
 
 ### HistoryListView
 
@@ -77,15 +89,28 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 | `testTabSwitching_navigatesBetweenTodayAndHistory` | タブ切り替えで画面が遷移する |
 | `testHistoryToDetail_pushesAndPops` | 履歴→詳細への push/pop ナビゲーション |
 
-### 2. HomeRecordingUITests（5テスト）
+### 2. HomeRecordingUITests（1テスト）
+
+録音UIをモーダルに移行したことで、複数の独立したテストケースを1つの統合フローテストに統合した。
 
 | テスト | 検証内容 |
 |-------|---------|
-| `testInitialState_showsRecordButtonOnly` | 初期状態で録音ボタンのみ表示 |
-| `testStartRecording_showsPauseAndStopButtons` | 録音開始で一時停止・停止ボタン表示 |
-| `testPauseRecording_showsResumeButton` | 一時停止で再開ボタン表示 |
-| `testStopRecording_addsRecordingToList` | 停止で録音リストにエントリ追加 |
-| `testMultipleRecordings_appearInOrder` | 複数録音が連番順に表示 |
+| `testRecordingModalFlow` | 録音ボタン → モーダル → 一時停止 → 再開 → 停止 → 書き起こし → 閉じる → 2回目録音 → 行数確認まで12ステップを通しで検証 |
+
+**テストステップ詳細:**
+
+1. `home.recordButton` の存在確認
+2. 録音ボタンタップ → モーダルが開き録音開始
+3. モーダル要素（`recording.duration` / `recording.waveform` / `recording.pauseButton` / `recording.stopButton`）の存在確認
+4. 一時停止ボタンタップ → `recording.resumeButton` に切り替わることを確認
+5. 再開ボタンタップ → `recording.pauseButton` に戻ることを確認
+6. 停止ボタンタップ → 書き起こし開始
+7. `recording.transcriptionResult` が表示されることを確認
+8. スワイプダウンでモーダルを閉じる
+9. `home.recordingRow.1` がリストに追加されることを確認
+10. 2回目の録音開始（`isHittable` predicate で安定待機）
+11. 停止 → 書き起こし結果を確認 → スワイプで閉じる
+12. `home.recordingRow.1` と `home.recordingRow.2` が両方存在することを確認
 
 ### 3. HistoryListUITests（4テスト）
 


### PR DESCRIPTION
Closes #30

## 変更内容

- `RecordingModalView.swift` を新規作成（録音時間、波形、一時停止/再開/停止ボタン、書き起こし結果表示）
- `HomeView.swift` から録音中UIを削除し、録音開始ボタン + モーダル表示に変更
- `HomeViewModel.swift` にTranscriptionStateとstartTranscription()を追加
- `HomeRecordingUITests.swift` を10ステップのフローテストに統合

Generated with [Claude Code](https://claude.ai/code)