### PR TITLE
Add path filters to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,17 @@ name: Test
 on:
   push:
     branches: [develop]
+    paths:
+      - 'MindEcho/**'
+      - 'Packages/**'
+      - 'MindEcho.xcworkspace/**'
+      - '.github/workflows/test.yml'
   pull_request:
+    paths:
+      - 'MindEcho/**'
+      - 'Packages/**'
+      - 'MindEcho.xcworkspace/**'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要

GitHub Actions のテストワークフローに path フィルターを追加し、関連ファイルの変更時のみワークフローが実行されるようにしました。

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [x] ビルド・CI設定の変更
- [ ] その他

## 変更内容

`.github/workflows/test.yml` に `paths` フィルターを追加しました。以下のパスに変更があった場合のみテストワークフローが実行されます：

- `MindEcho/**` - メインアプリケーションコード
- `Packages/**` - 依存パッケージ
- `MindEcho.xcworkspace/**` - Xcode ワークスペース設定
- `.github/workflows/test.yml` - ワークフロー自体

このフィルターは `push` (develop ブランチ) と `pull_request` イベントの両方に適用されます。

## 影響範囲

- 対象画面: なし
- 対象機能: CI/CD パイプライン

## テスト

- [x] ビルド・CI設定の変更のため、実際のワークフロー実行で検証されます

## チェックリスト

- [x] コードがビルドできることを確認した（YAML 構文は有効）
- [x] 既存の機能にデグレがないことを確認した（ワークフロー機能は変わらず、実行条件のみ追加）

## レビュアーへの補足

この変更により、ドキュメントやその他の無関係なファイルの変更時にテストワークフローが不要に実行されることを防ぎ、CI/CD の効率を向上させます。

https://claude.ai/code/session_01Ba3zNyF77z99TDyj1s9XUm