### PR TITLE
Add PR number and title to TestFlight changelog

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -46,6 +46,8 @@ jobs:
               pull_number: context.issue.number
             });
             core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('number', pr.data.number);
+            core.setOutput('title', pr.data.title);
 
       - uses: actions/checkout@v5
         with:
@@ -93,6 +95,8 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
         run: bundle exec fastlane beta
 
       - name: Comment on PR (success)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,6 +45,14 @@ platform :ios do
 
     build_app(**build_args)
 
-    upload_to_testflight(api_key: api_key)
+    upload_args = { api_key: api_key }
+
+    pr_number = ENV["PR_NUMBER"]
+    pr_title = ENV["PR_TITLE"]
+    if pr_number && !pr_number.empty? && pr_title && !pr_title.empty?
+      upload_args[:changelog] = "##{pr_number} #{pr_title}"
+    end
+
+    upload_to_testflight(**upload_args)
   end
 end


### PR DESCRIPTION
## 概要

TestFlightへのビルドアップロード時に、PRの番号とタイトルをchangelogに自動的に含めるようにしました。

## 変更の種類

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [x] ビルド・CI設定の変更
- [ ] その他

## 変更内容

### Fastfile
- `upload_to_testflight`の呼び出しを`upload_args`ハッシュを使用した形式に変更
- 環境変数`PR_NUMBER`と`PR_TITLE`から取得したPR情報をchangelogとして設定
- PR情報が存在する場合、`#<PR番号> <PRタイトル>`形式でchangelogに追加

### GitHub Actions Workflow (testflight.yml)
- PR取得ステップで`number`と`title`を出力として追加
- fastlaneの実行時に`PR_NUMBER`と`PR_TITLE`環境変数を設定

## 影響範囲

- TestFlightへのビルドアップロード時のchangelog内容
- CI/CDパイプライン（testflight.yml）

## テスト

- CI/CDパイプラインが正常に動作することで検証
- TestFlightでchangelogが正しく表示されることを確認

## チェックリスト

- [x] コードがビルドできることを確認した
- [x] 既存の機能にデグレがないことを確認した

## レビュアーへの補足

PR情報が環境変数で提供されない場合（例：手動実行時）でも、changelogなしで正常に動作するようにガード条件を設けています。

https://claude.ai/code/session_01SNekTWHYxcqNpmdyjNnUBA