### PR TITLE
Optimize CI workflow: artifact-based parallel tests to eliminate redundant builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ env:
   WORKSPACE: MindEcho.xcworkspace
 
 jobs:
-  tests:
-    name: Tests
+  build:
+    name: Build
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -43,6 +43,27 @@ jobs:
             -destination "$DESTINATION" \
             -derivedDataPath DerivedData
 
+      - name: Upload DerivedData
+        uses: actions/upload-artifact@v4
+        with:
+          name: derived-data
+          path: DerivedData
+          retention-days: 1
+
+  unit-tests:
+    name: Unit Tests
+    needs: build
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download DerivedData
+        uses: actions/download-artifact@v4
+        with:
+          name: derived-data
+          path: DerivedData
+
       - name: Run Unit Tests (MindEchoTests)
         run: |
           xcodebuild test-without-building \
@@ -51,6 +72,20 @@ jobs:
             -destination "$DESTINATION" \
             -derivedDataPath DerivedData \
             -only-testing:MindEchoTests
+
+  ui-tests:
+    name: UI Tests
+    needs: build
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download DerivedData
+        uses: actions/download-artifact@v4
+        with:
+          name: derived-data
+          path: DerivedData
 
       - name: Run UI Tests (MindEchoUITests)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,11 @@ jobs:
             -destination "$DESTINATION" \
             -derivedDataPath DerivedData
 
-      - name: Upload DerivedData
+      - name: Upload Build Products
         uses: actions/upload-artifact@v4
         with:
-          name: derived-data
-          path: DerivedData
+          name: build-products
+          path: DerivedData/Build/Products
           retention-days: 1
 
   unit-tests:
@@ -58,11 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download DerivedData
+      - name: Download Build Products
         uses: actions/download-artifact@v4
         with:
-          name: derived-data
-          path: DerivedData
+          name: build-products
+          path: DerivedData/Build/Products
 
       - name: Run Unit Tests (MindEchoTests)
         run: |
@@ -81,11 +81,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download DerivedData
+      - name: Download Build Products
         uses: actions/download-artifact@v4
         with:
-          name: derived-data
-          path: DerivedData
+          name: build-products
+          path: DerivedData/Build/Products
 
       - name: Run UI Tests (MindEchoUITests)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,32 +28,35 @@ env:
   WORKSPACE: MindEcho.xcworkspace
 
 jobs:
-  unit-tests:
-    name: Unit Tests
+  tests:
+    name: Tests
     runs-on: macos-26
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+
+      - name: Build for Testing
+        run: |
+          xcodebuild build-for-testing \
+            -workspace $WORKSPACE \
+            -scheme MindEcho \
+            -destination "$DESTINATION" \
+            -derivedDataPath DerivedData
 
       - name: Run Unit Tests (MindEchoTests)
         run: |
-          xcodebuild test \
+          xcodebuild test-without-building \
             -workspace $WORKSPACE \
             -scheme MindEcho \
             -destination "$DESTINATION" \
+            -derivedDataPath DerivedData \
             -only-testing:MindEchoTests
-
-  ui-tests:
-    name: UI Tests
-    runs-on: macos-26
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6
 
       - name: Run UI Tests (MindEchoUITests)
         run: |
-          xcodebuild test \
+          xcodebuild test-without-building \
             -workspace $WORKSPACE \
             -scheme MindEcho \
             -destination "$DESTINATION" \
+            -derivedDataPath DerivedData \
             -only-testing:MindEchoUITests


### PR DESCRIPTION
## 概要

GitHub ActionsのテストワークフローをOptimizeしました。ビルドを1回だけ実行し、その成果物（DerivedData）をartifactとして共有することで、ユニットテストとUIテストを並列に実行しつつ重複ビルドを排除します。

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [x] ビルド・CI設定の変更
- [ ] その他

## 変更内容

### ワークフロー構造の最適化（3ジョブ構成）

変更前: `unit-tests` と `ui-tests` の2ジョブがそれぞれ独立にビルド+テスト実行
変更後: `build` → `unit-tests` / `ui-tests` の3ジョブ構成

```
build (ビルド1回)
  ├── unit-tests (並列)
  └── ui-tests   (並列)
```

### 具体的な変更

1. **`build` ジョブを新設**
   - `xcodebuild build-for-testing` でテスト用ビルドを実行
   - `actions/upload-artifact@v4` で `DerivedData` をアップロード（retention: 1日）

2. **`unit-tests` / `ui-tests` ジョブ**
   - `needs: build` で build ジョブ完了を待機
   - `actions/download-artifact@v4` で DerivedData をダウンロード
   - `xcodebuild test-without-building` でビルド済み成果物を使ってテスト実行

### 期待される効果

| | 変更前 | 変更後 |
|---|---|---|
| ビルド回数 | 2回（各ジョブ） | 1回 |
| テスト実行 | 並列 | 並列（維持） |
| Wall Time | max(B+U, B+UI) | B + artifact転送 + max(U, UI) |
| ジョブ数 | 2 | 3 |

- ビルド1回分の時間を削減
- テストの並列性は維持
- artifact 転送のオーバーヘッドはあるが、ビルド時間 > 転送時間であれば全体として高速化

## 影響範囲

- 対象画面: なし
- 対象機能: CI/CDパイプライン

## テスト

- [x] 既存のテストが正常に実行されることを確認（CI実行で検証）

## チェックリスト

- [x] ワークフロー構文が正しいことを確認した
- [x] 既存のテスト実行に影響がないことを確認した

## レビュアーへの補足

このPRは純粋なCI設定の最適化です。アプリケーションコードへの変更はなく、テスト内容も変わりません。ワークフロー実行時のパフォーマンス向上のみが目的です。

https://claude.ai/code/session_01PFDcodFczYxpzvPw1p2zoh