### PR TITLE
docs: Add Definition of Done checklist to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,32 @@ JournalEntry (1日1エントリ)
     └── transcription: String?   (書き起こしテキスト、SwiftData で永続化)
 ```
 
+## Definition of Done
+
+Claude がタスクを「完了」と判断する前に、以下の全項目を満たしていることを確認すること。
+
+### 1. ビルド成功
+
+- `xcodebuild build` がエラーなしで通ること
+
+### 2. テスト通過
+
+- 変更に関連する既存テスト（Unit / UI）が全て通ること
+- 新機能を追加した場合は、対応するテストを追加すること
+
+### 3. ドキュメントの更新
+
+- 新しい型・プロトコル・モジュールを追加した場合は、CLAUDE.md の該当セクション（Architecture, File Structure 等）を更新すること
+- 設計上の重要な判断を行った場合は、`docs/` 配下のドキュメントに反映すること
+
+### 4. UI 変更時の追加要件
+
+UI に変更を加えた場合は、以下も必須:
+
+- `docs/ui-test-design.md` の更新（Accessibility Identifier 一覧、テストケース一覧）
+- 対応する UITest の実装追加・更新（`MindEchoUITests/`）
+- 新規 UI 要素には `.accessibilityIdentifier()` を付与すること
+
 ## Important Notes for Claude
 
 - **設計ドキュメント**: `/docs/design-prompt.md` に詳細仕様あり


### PR DESCRIPTION
## 概要

CLAUDE.md に「Definition of Done」セクションを追加し、タスク完了時に確認すべき基準を明文化しました。

## 変更の種類

- [x] ドキュメント更新

## 変更内容

CLAUDE.md に以下の内容を追加しました：

### Definition of Done セクション
Claude がタスクを完了と判断する前に確認すべき4つのカテゴリを定義：

1. **ビルド成功**: `xcodebuild build` がエラーなしで通ること
2. **テスト通過**: 既存テストの通過と新機能時のテスト追加
3. **ドキュメント更新**: 新規型・プロトコル・モジュール追加時の CLAUDE.md 更新、設計判断時の docs/ 更新
4. **UI 変更時の追加要件**: 
   - `docs/ui-test-design.md` の更新
   - UITest の実装追加・更新
   - `.accessibilityIdentifier()` の付与

## 影響範囲

- ドキュメント: CLAUDE.md のみ
- 対象機能: なし（ドキュメント更新のため、実装への影響なし）

## テスト

- [ ] N/A（ドキュメント更新のため）

## チェックリスト

- [x] ドキュメントの内容が正確で明確であることを確認した
- [x] 既存の設計・アーキテクチャと矛盾がないことを確認した

## レビュアーへの補足

このセクションは、開発プロセスの品質基準を明確にするためのものです。特に UI 変更時の要件（Accessibility Identifier の付与、UITest の実装）は、プロジェクトの保守性と自動テストの充実を目的としています。

https://claude.ai/code/session_013uvrXqqv3S4uqS5hzTF65n