### PR TITLE
Add summarization feature for transcriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, Mocks | `HomeView`, `HomeViewModel`, `ExportServiceImpl` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, Mocks | `HomeView`, `HomeViewModel`, `ExportServiceImpl`, `SummarizationService` 等 |
 
 ### Design Principles
 
@@ -133,7 +133,8 @@ xcodebuild test \
 ```
 JournalEntry (1日1エントリ)
 └── recordings: [Recording]      (音声記録、連番管理)
-    └── transcription: String?   (書き起こしテキスト、SwiftData で永続化)
+    ├── transcription: String?   (書き起こしテキスト、SwiftData で永続化)
+    └── summary: String?         (要約テキスト、Apple Foundation Models で生成、SwiftData で永続化)
 ```
 
 ## Definition of Done

--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -99,6 +99,7 @@ struct MindEchoApp: App {
                 duration: duration
             )
             recording.transcription = "サンプル書き起こしテキスト \(dayOffset)日前"
+            recording.summary = "サンプル要約 \(dayOffset)日前"
             entry.recordings.append(recording)
             context.insert(entry)
         }

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -10,6 +10,9 @@ struct SummarizationService {
     }
 
     static var isAvailable: Bool {
-        LanguageModelSession.isAvailable
+        if case .available = SystemLanguageModel.default.availability {
+            return true
+        }
+        return false
     }
 }

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -1,0 +1,15 @@
+import Foundation
+import FoundationModels
+
+struct SummarizationService {
+    func summarize(text: String) async throws -> String {
+        let session = LanguageModelSession()
+        let prompt = "以下の書き起こしテキストを簡潔に要約してください。要約のみを出力し、余計な前置きは不要です。\n\n\(text)"
+        let response = try await session.respond(to: prompt)
+        return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static var isAvailable: Bool {
+        LanguageModelSession.isAvailable
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -12,7 +12,16 @@ final class TranscriptionViewModel {
         case failure(String)
     }
 
+    enum SummaryState: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+        case unavailable
+    }
+
     private(set) var state: State = .idle
+    private(set) var summaryState: SummaryState = .idle
 
     @ObservationIgnored
     var transcribe: (URL, Locale) async throws -> String = TranscriptionService().transcribe
@@ -24,11 +33,16 @@ final class TranscriptionViewModel {
     var requestAuthorization: (@escaping (SFSpeechRecognizerAuthorizationStatus) -> Void) -> Void = {
         SFSpeechRecognizer.requestAuthorization($0)
     }
+    @ObservationIgnored
+    var summarize: (String) async throws -> String = SummarizationService().summarize
+    @ObservationIgnored
+    var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
 
     func startTranscription(recording: Recording) async {
         // 保存済みの書き起こしがあれば即表示
         if let existing = recording.transcription {
             state = .success(existing)
+            await startSummarization(recording: recording, text: existing)
             return
         }
 
@@ -60,9 +74,37 @@ final class TranscriptionViewModel {
             } else {
                 recording.transcription = text
                 state = .success(text)
+                await startSummarization(recording: recording, text: text)
             }
         } catch {
             state = .failure("書き起こしに失敗しました: \(error.localizedDescription)")
+        }
+    }
+
+    func startSummarization(recording: Recording, text: String) async {
+        // 保存済みの要約があれば即表示
+        if let existing = recording.summary {
+            summaryState = .success(existing)
+            return
+        }
+
+        guard isSummarizationAvailable() else {
+            summaryState = .unavailable
+            return
+        }
+
+        summaryState = .loading
+
+        do {
+            let summary = try await summarize(text)
+            if summary.isEmpty {
+                summaryState = .failure("要約結果が空でした。")
+            } else {
+                recording.summary = summary
+                summaryState = .success(summary)
+            }
+        } catch {
+            summaryState = .failure("要約に失敗しました: \(error.localizedDescription)")
         }
     }
 }

--- a/MindEcho/MindEcho/Views/EntryDetailView.swift
+++ b/MindEcho/MindEcho/Views/EntryDetailView.swift
@@ -53,7 +53,13 @@ struct EntryDetailView: View {
                             }
                             .buttonStyle(.borderless)
 
-                            if let transcription = recording.transcription {
+                            if let summary = recording.summary {
+                                Text(summary)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                                    .accessibilityIdentifier("detail.summary.\(recording.sequenceNumber)")
+                            } else if let transcription = recording.transcription {
                                 Text(transcription)
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -55,7 +55,13 @@ struct HomeView: View {
                                         }
                                     }
 
-                                    if let transcription = recording.transcription {
+                                    if let summary = recording.summary {
+                                        Text(summary)
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(2)
+                                            .accessibilityIdentifier("home.summary.\(recording.sequenceNumber)")
+                                    } else if let transcription = recording.transcription {
                                         Text(transcription)
                                             .font(.subheadline)
                                             .foregroundStyle(.secondary)

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -15,10 +15,14 @@ struct TranscriptionView: View {
                         .accessibilityIdentifier("transcription.loading")
                 case .success(let text):
                     ScrollView {
-                        Text(text)
-                            .padding()
-                            .textSelection(.enabled)
-                            .accessibilityIdentifier("transcription.resultText")
+                        VStack(alignment: .leading, spacing: 16) {
+                            summarySection
+                            Text(text)
+                                .padding(.horizontal)
+                                .textSelection(.enabled)
+                                .accessibilityIdentifier("transcription.resultText")
+                        }
+                        .padding(.vertical)
                     }
                 case .failure(let message):
                     ContentUnavailableView {
@@ -40,7 +44,56 @@ struct TranscriptionView: View {
                 }
                 viewModel.checkAuthorization = { .authorized }
             }
+            if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
+                viewModel.summarize = { text in
+                    try await Task.sleep(for: .milliseconds(300))
+                    return "これはモックの要約結果です。"
+                }
+                viewModel.isSummarizationAvailable = { true }
+            }
             await viewModel.startTranscription(recording: recording)
+        }
+    }
+
+    @ViewBuilder
+    private var summarySection: some View {
+        switch viewModel.summaryState {
+        case .idle:
+            EmptyView()
+        case .loading:
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                ProgressView("要約を生成中...")
+                    .accessibilityIdentifier("transcription.summaryLoading")
+            }
+            .padding(.horizontal)
+        case .success(let summary):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                Text(summary)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier("transcription.summaryText")
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+            Divider()
+                .padding(.horizontal)
+        case .failure(let message):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("transcription.summaryError")
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+            Divider()
+                .padding(.horizontal)
+        case .unavailable:
+            EmptyView()
         }
     }
 }

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Speech
 import MindEchoCore
 @testable import MindEcho
 

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+import MindEchoCore
+@testable import MindEcho
+
+@MainActor
+struct SummarizationTests {
+    private func makeRecording(transcription: String? = nil, summary: String? = nil) -> Recording {
+        let recording = Recording(
+            sequenceNumber: 1,
+            audioFileName: "20260222_120000.m4a",
+            duration: 10.0,
+            transcription: transcription,
+            summary: summary
+        )
+        return recording
+    }
+
+    private func makeViewModel(
+        summarizeResult: String = "テスト要約結果",
+        available: Bool = true
+    ) -> TranscriptionViewModel {
+        let vm = TranscriptionViewModel()
+        vm.checkAuthorization = { .authorized }
+        vm.transcribe = { _, _ in "テスト書き起こし結果" }
+        vm.summarize = { _ in summarizeResult }
+        vm.isSummarizationAvailable = { available }
+        return vm
+    }
+
+    @Test func initialSummaryState_isIdle() {
+        let vm = TranscriptionViewModel()
+        #expect(vm.summaryState == .idle)
+    }
+
+    @Test func startSummarization_savesSummaryToRecording() async {
+        let vm = makeViewModel()
+        let recording = makeRecording(transcription: "既存テキスト")
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(recording.summary == "テスト要約結果")
+        #expect(vm.summaryState == .success("テスト要約結果"))
+    }
+
+    @Test func startSummarization_existingSummary_showsImmediately() async {
+        let vm = makeViewModel()
+        var summarizeCalled = false
+        vm.summarize = { _ in
+            summarizeCalled = true
+            return "新しい要約"
+        }
+
+        let recording = makeRecording(transcription: "テキスト", summary: "既存の要約")
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.summaryState == .success("既存の要約"))
+        #expect(!summarizeCalled)
+    }
+
+    @Test func startSummarization_unavailableDevice_showsUnavailable() async {
+        let vm = makeViewModel(available: false)
+        let recording = makeRecording(transcription: "テキスト")
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.summaryState == .unavailable)
+        #expect(recording.summary == nil)
+    }
+
+    @Test func startSummarization_emptyResult_showsFailure() async {
+        let vm = makeViewModel(summarizeResult: "")
+        let recording = makeRecording(transcription: "テキスト")
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.summaryState == .failure("要約結果が空でした。"))
+        #expect(recording.summary == nil)
+    }
+
+    @Test func startSummarization_error_showsFailure() async {
+        let vm = makeViewModel()
+        vm.summarize = { _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
+        }
+        let recording = makeRecording(transcription: "テキスト")
+
+        await vm.startTranscription(recording: recording)
+
+        if case .failure(let message) = vm.summaryState {
+            #expect(message.contains("テストエラー"))
+        } else {
+            Issue.record("Expected failure state")
+        }
+        #expect(recording.summary == nil)
+    }
+
+    @Test func startSummarization_failure_doesNotSaveSummary() async {
+        let vm = makeViewModel()
+        vm.summarize = { _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
+        }
+        let recording = makeRecording(transcription: "テキスト")
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(recording.summary == nil)
+    }
+
+    @Test func transcriptionSuccess_triggersSummarization() async {
+        let vm = makeViewModel()
+        let recording = makeRecording()
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.state == .success("テスト書き起こし結果"))
+        #expect(vm.summaryState == .success("テスト要約結果"))
+        #expect(recording.transcription == "テスト書き起こし結果")
+        #expect(recording.summary == "テスト要約結果")
+    }
+
+    @Test func transcriptionFailure_doesNotTriggerSummarization() async {
+        let vm = makeViewModel()
+        vm.transcribe = { _, _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
+        }
+        let recording = makeRecording()
+
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.summaryState == .idle)
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -6,7 +6,7 @@ final class TranscriptionUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription"]
+        app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization"]
     }
 
     @MainActor
@@ -33,6 +33,24 @@ final class TranscriptionUITests: XCTestCase {
         let resultText = app.staticTexts["transcription.resultText"]
         XCTAssertTrue(resultText.waitForExistence(timeout: 10))
         XCTAssertTrue(resultText.label.contains("モックの書き起こし結果"))
+    }
+
+    @MainActor
+    func testTranscription_showsSummaryAboveResultText() throws {
+        app.launch()
+
+        let transcribeButton = app.buttons["home.transcribeButton.1"]
+        XCTAssertTrue(transcribeButton.waitForExistence(timeout: 5))
+        transcribeButton.tap()
+
+        // Summary text should appear above the transcription result
+        let summaryText = app.staticTexts["transcription.summaryText"]
+        XCTAssertTrue(summaryText.waitForExistence(timeout: 10))
+        XCTAssertTrue(summaryText.label.contains("モックの要約結果"))
+
+        // Result text should also be visible
+        let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/Packages/MindEchoCore/Sources/MindEchoCore/Recording.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/Recording.swift
@@ -9,6 +9,7 @@ public class Recording {
     public var duration: TimeInterval
     public var recordedAt: Date
     public var transcription: String?
+    public var summary: String?
 
     @Relationship(inverse: \JournalEntry.recordings)
     public var entry: JournalEntry?
@@ -17,13 +18,19 @@ public class Recording {
         transcription != nil
     }
 
+    public var hasSummary: Bool {
+        summary != nil
+    }
+
     public init(id: UUID = UUID(), sequenceNumber: Int, audioFileName: String,
-         duration: TimeInterval, recordedAt: Date = Date(), transcription: String? = nil) {
+         duration: TimeInterval, recordedAt: Date = Date(), transcription: String? = nil,
+         summary: String? = nil) {
         self.id = id
         self.sequenceNumber = sequenceNumber
         self.audioFileName = audioFileName
         self.duration = duration
         self.recordedAt = recordedAt
         self.transcription = transcription
+        self.summary = summary
     }
 }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -14,6 +14,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | `--mock-recorder` | MockAudioRecorderService を注入（マイク不要で録音UI状態遷移をテスト） |
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
 | `--mock-transcription` | TranscriptionView 内の書き起こしクロージャを mock に差し替え（Speech フレームワーク不要でテスト） |
+| `--mock-summarization` | TranscriptionView 内の要約クロージャを mock に差し替え（FoundationModels 不要でテスト） |
 
 ## マイク非依存のテスト方式
 
@@ -41,6 +42,7 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 - `home.recordingRow.{n}`
 - `home.transcribeButton.{n}`
 - `home.transcription.{n}` — 録音セル内の書き起こしテキストプレビュー
+- `home.summary.{n}` — 録音セル内の要約テキストプレビュー（要約がある場合、書き起こしプレビューより優先表示）
 - `home.transcriptionSheet`
 - `home.shareButton` — 共有メニューボタン（録音が存在する場合のみ表示）
 - `home.shareAudioButton` — 共有メニュー内の「音声を共有」ボタン
@@ -74,6 +76,9 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 - `transcription.loading`
 - `transcription.resultText`
 - `transcription.error`
+- `transcription.summaryLoading` — 要約生成中のプログレス表示
+- `transcription.summaryText` — 要約結果テキスト
+- `transcription.summaryError` — 要約エラーメッセージ
 
 ### EntryDetailView
 
@@ -82,10 +87,11 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 - `detail.recordingRow.{n}`
 - `detail.deleteButton.{n}`
 - `detail.shareButton`
+- `detail.summary.{n}` — 録音セル内の要約テキストプレビュー
 - `detail.shareAudioButton` — 共有メニュー内の「音声を共有」ボタン
 - `detail.shareTranscriptButton` — 共有メニュー内の「テキストを共有」ボタン
 
-## テストケース（5カテゴリ・16テスト）
+## テストケース（5カテゴリ・17テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -137,12 +143,13 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 | `testShareTranscriptButton_presentsActivitySheet` | 共有ボタンタップで共有タイプ選択メニュー表示 → 「テキストを共有」選択で Activity Sheet 表示 |
 | `testSwipeToDelete_removesRecording` | スワイプ削除で録音が削除される |
 
-### 5. TranscriptionUITests（3テスト）
+### 5. TranscriptionUITests（4テスト）
 
 | テスト | 検証内容 |
 |-------|---------|
 | `testTranscribeButton_opensTranscriptionSheet` | 書き起こしボタンタップでモーダル表示・結果テキスト表示 |
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
+| `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
 | `testTranscription_dismissSheet` | シートをスワイプで閉じてホーム画面に戻る |
 
 ## テスト対象外（明示的に除外）
@@ -153,6 +160,7 @@ UIテストは **UI状態遷移**（ボタンの表示/非表示、有効/無効
 - iOS Share Sheet 操作 → システムUI
 - バックグラウンド録音 → 実機テスト
 - 実音声の書き起こし精度 → Speech フレームワーク依存、実機テスト
+- Apple Foundation Models の要約精度 → FoundationModels 依存、対応デバイスでの実機テスト
 
 ## 実装順序
 


### PR DESCRIPTION
## 概要

音声書き起こし後に自動的にテキストを要約する機能を追加しました。要約結果は書き起こしテキストの上に表示され、ユーザーが素早く内容を把握できるようになります。

## 変更の種類

- [x] 新機能
- [x] UI/デザイン変更
- [x] テストの追加・修正
- [x] ドキュメント更新

## 変更内容

### 新規ファイル
- **SummarizationService**: FoundationModels フレームワークを使用してテキスト要約を実行するサービス
- **SummarizationTests**: 要約機能の包括的なユニットテスト（9テスト）

### TranscriptionViewModel の拡張
- `SummaryState` enum を追加（idle, loading, success, failure, unavailable）
- `summaryState` プロパティを追加
- `startSummarization()` メソッドを実装
  - 既存の要約がある場合は即座に表示
  - デバイスが要約機能に対応していない場合は unavailable 状態
  - 空の結果やエラーを適切に処理

### TranscriptionView の UI 更新
- 要約セクション（`summarySection`）を追加
  - 要約生成中のプログレス表示
  - 要約成功時のテキスト表示（選択可能）
  - エラーメッセージ表示
- 要約を書き起こしテキストの上に配置
- モック要約機能（`--mock-summarization` フラグ）を追加

### Recording モデルの拡張
- `summary` プロパティを追加
- `hasSummary` 計算プロパティを追加

### ビュー層の更新
- **HomeView**: 要約がある場合は要約を優先表示（`home.summary.{n}`）
- **EntryDetailView**: 要約がある場合は要約を優先表示（`detail.summary.{n}`）

### テスト
- **SummarizationTests**: 要約機能の全シナリオをカバー
  - 初期状態、成功時、既存要約の再利用、デバイス非対応、空結果、エラーハンドリング
  - 書き起こし成功時の自動要約トリガー、失敗時の要約スキップ
- **TranscriptionUITests**: 要約表示の UI テストを追加

### ドキュメント更新
- `docs/ui-test-design.md` に要約関連の accessibility identifier を追加
- テストケース数を 16 から 17 に更新
- `CLAUDE.md` に SummarizationService を記載

## 影響範囲

- 対象画面: TranscriptionView, HomeView, EntryDetailView
- 対象機能: 音声書き起こし後の自動要約、要約結果の表示・保存

## テスト

- [x] ユニットテストを追加・更新した（SummarizationTests: 9テスト）
- [x] UIテストを追加・更新した（TranscriptionUITests に要約表示テスト追加）
- [x] シミュレータで動作確認した（モック要約機能で検証可能）

## チェックリスト

- [x] コードがビルドできることを確認した
- [x] 不要なデバッグコード・print文を削除した
- [x]

https://claude.ai/code/session_01RMBCCzK1DcCK3zjpQv6M4P