### PR TITLE
共有ボタンをツールバーから日付セクションヘッダーに移動

### DIFF
--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -42,13 +42,6 @@ struct HomeView: View {
                 .padding(.vertical)
             }
             .navigationTitle("MindEcho")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    if viewModel.todayEntry != nil && !(viewModel.todayEntry?.recordings.isEmpty ?? true) {
-                        shareMenu(for: viewModel.todayEntry!)
-                    }
-                }
-            }
             .sheet(isPresented: Binding(
                 get: { shareItems != nil },
                 set: { if !$0 { shareItems = nil } }
@@ -91,8 +84,14 @@ struct HomeView: View {
                     .accessibilityIdentifier("home.emptyState")
             }
         } header: {
-            Text(DateHelper.displayString(for: DateHelper.today()))
-                .accessibilityIdentifier("home.dateLabel")
+            HStack {
+                Text(DateHelper.displayString(for: DateHelper.today()))
+                    .accessibilityIdentifier("home.dateLabel")
+                Spacer()
+                if let entry = viewModel.todayEntry, !entry.recordings.isEmpty {
+                    shareMenu(for: entry, prefix: "home")
+                }
+            }
         }
     }
 
@@ -105,8 +104,12 @@ struct HomeView: View {
                 recordingRow(recording, isToday: false, entry: entry)
             }
         } header: {
-            Text(DateHelper.displayString(for: entry.date))
-                .accessibilityIdentifier("home.sectionHeader.\(dateTag(entry.date))")
+            HStack {
+                Text(DateHelper.displayString(for: entry.date))
+                    .accessibilityIdentifier("home.sectionHeader.\(dateTag(entry.date))")
+                Spacer()
+                shareMenu(for: entry, prefix: "past", dateTag: dateTag(entry.date))
+            }
         }
     }
 
@@ -221,25 +224,26 @@ struct HomeView: View {
 
     // MARK: - Share Menu
 
-    private func shareMenu(for entry: JournalEntry) -> some View {
-        Menu {
+    private func shareMenu(for entry: JournalEntry, prefix: String, dateTag: String? = nil) -> some View {
+        let suffix = dateTag.map { ".\($0)" } ?? ""
+        return Menu {
             Button {
                 exportAndShareAudio(entry: entry)
             } label: {
                 Label("音声を共有", systemImage: "waveform")
             }
-            .accessibilityIdentifier("home.shareAudioButton")
+            .accessibilityIdentifier("\(prefix).shareAudioButton\(suffix)")
 
             Button {
                 exportAndShareTranscript(entry: entry)
             } label: {
                 Label("テキストを共有", systemImage: "doc.text")
             }
-            .accessibilityIdentifier("home.shareTranscriptButton")
+            .accessibilityIdentifier("\(prefix).shareTranscriptButton\(suffix)")
         } label: {
             Image(systemName: "square.and.arrow.up")
         }
-        .accessibilityIdentifier("home.shareButton")
+        .accessibilityIdentifier("\(prefix).shareButton\(suffix)")
     }
 
     // MARK: - Export

--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -32,7 +32,10 @@ final class EntryDetailUITests: XCTestCase {
     func testShareButton_presentsActivitySheet() throws {
         app.launch()
 
-        let shareBtn = app.buttons["home.shareButton"]
+        // Share button is now in the section header, use descendants query
+        let shareBtn = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.shareButton'")
+        ).firstMatch
         XCTAssertTrue(shareBtn.waitForExistence(timeout: 5))
         shareBtn.tap()
 
@@ -50,7 +53,10 @@ final class EntryDetailUITests: XCTestCase {
     func testShareTranscriptButton_presentsActivitySheet() throws {
         app.launch()
 
-        let shareBtn = app.buttons["home.shareButton"]
+        // Share button is now in the section header, use descendants query
+        let shareBtn = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.shareButton'")
+        ).firstMatch
         XCTAssertTrue(shareBtn.waitForExistence(timeout: 5))
         shareBtn.tap()
 

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -48,13 +48,16 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `home.summary.{n}` — 今日の録音セル内の要約テキストプレビュー（要約がある場合、書き起こしプレビューより優先表示）
 - `home.deleteButton.{n}` — 今日の録音のスワイプ削除ボタン
 - `home.transcriptionSheet` — 書き起こしシート
-- `home.shareButton` — 共有メニューボタン（今日の録音が存在する場合のみ表示）
+- `home.shareButton` — 共有メニューボタン（今日のセクションヘッダー内、録音が存在する場合のみ表示）
 - `home.shareAudioButton` — 共有メニュー内の「音声を共有」ボタン
 - `home.shareTranscriptButton` — 共有メニュー内の「テキストを共有」ボタン
 
 **過去のセクション**
 
 - `home.sectionHeader.{date}` — 過去の日付セクションヘッダー（date = yyyyMMdd）
+- `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン
+- `past.shareAudioButton.{date}` — 過去の共有メニュー内の「音声を共有」ボタン
+- `past.shareTranscriptButton.{date}` — 過去の共有メニュー内の「テキストを共有」ボタン
 - `past.recordingRow.{date}.{n}` — 過去の録音行
 - `past.transcribeButton.{date}.{n}` — 過去の録音の書き起こしボタン
 - `past.transcription.{date}.{n}` — 過去の録音セル内の書き起こしテキストプレビュー
@@ -134,8 +137,8 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | テスト | 検証内容 |
 |-------|---------|
 | `testHomeView_showsDateAndRecordingsList` | 日付と録音リストの表示 |
-| `testShareButton_presentsActivitySheet` | 共有ボタンタップで共有タイプ選択メニュー表示 → 「音声を共有」選択で Activity Sheet 表示 |
-| `testShareTranscriptButton_presentsActivitySheet` | 共有ボタンタップで共有タイプ選択メニュー表示 → 「テキストを共有」選択で Activity Sheet 表示 |
+| `testShareButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「音声を共有」選択で Activity Sheet 表示 |
+| `testShareTranscriptButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「テキストを共有」選択で Activity Sheet 表示 |
 | `testSwipeToDelete_removesRecording` | スワイプ削除で録音が削除される |
 
 ### 5. TranscriptionUITests（4テスト）


### PR DESCRIPTION
右上のツールバー共有ボタンを廃止し、今日・過去の各日付セクション
ヘッダーに共有メニューを配置。過去のエントリからも直接共有可能に。

https://claude.ai/code/session_01WFcHarG5TRjvpwJtffTqfZ