### PR TITLE
feat: Recording Cell レイアウト変更に伴う UITest・ドキュメント更新 (#53)

### DIFF
--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -123,7 +123,7 @@ struct HomeView: View {
             : "\(dateTag(entry!.date)).\(recording.sequenceNumber)"
         let isCurrentlyPlaying = viewModel.playingRecordingId == recording.id && viewModel.isPlaying
 
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .center, spacing: 4) {
             // Main content area — tap navigates to TranscriptionView
             Button {
                 transcriptionTargetRecording = recording
@@ -140,7 +140,10 @@ struct HomeView: View {
                     viewModel.pausePlayback()
                 } label: {
                     Image(systemName: "pause.fill")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .accessibilityIdentifier("\(prefix).pauseButton.\(suffix)")
                 .id("\(prefix).pauseButton.\(suffix)")
             } else {
@@ -148,7 +151,10 @@ struct HomeView: View {
                     viewModel.playRecording(recording)
                 } label: {
                     Image(systemName: "play.fill")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .accessibilityIdentifier("\(prefix).playButton.\(suffix)")
                 .id("\(prefix).playButton.\(suffix)")
             }
@@ -165,6 +171,8 @@ struct HomeView: View {
                 }
             } label: {
                 Image(systemName: "ellipsis")
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .accessibilityIdentifier("\(prefix).moreButton.\(suffix)")
         }

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -117,74 +117,62 @@ struct HomeView: View {
 
     @ViewBuilder
     private func recordingRow(_ recording: Recording, isToday: Bool, entry: JournalEntry? = nil) -> some View {
-        let identifier = isToday
-            ? "home.recordingRow.\(recording.sequenceNumber)"
-            : "past.recordingRow.\(dateTag(entry!.date)).\(recording.sequenceNumber)"
+        let prefix = isToday ? "home" : "past"
+        let suffix = isToday
+            ? "\(recording.sequenceNumber)"
+            : "\(dateTag(entry!.date)).\(recording.sequenceNumber)"
         let isCurrentlyPlaying = viewModel.playingRecordingId == recording.id && viewModel.isPlaying
 
         HStack(alignment: .top, spacing: 8) {
-            // Use if/else with distinct .id() modifiers so SwiftUI fully recreates
-            // the element when play state changes. XCTest reliably detects new
-            // elements appearing/disappearing in the accessibility tree, whereas
-            // dynamic property changes (accessibilityValue, identifier updates on
-            // the same element) may not propagate reliably on iOS 26 SwiftUI List.
+            // Main content area — tap navigates to TranscriptionView
+            Button {
+                transcriptionTargetRecording = recording
+            } label: {
+                recordingRowContent(
+                    recording: recording, isToday: isToday, entry: entry)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("\(prefix).recordingRow.\(suffix)")
+
+            // Play / Pause button (distinct id for reliable XCTest detection)
             if isCurrentlyPlaying {
                 Button {
                     viewModel.pausePlayback()
                 } label: {
-                    recordingRowContent(
-                        recording: recording, isToday: isToday,
-                        entry: entry, isPlaying: true)
+                    Image(systemName: "pause.fill")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("\(identifier).pause")
-                .id("\(identifier).pause")
+                .accessibilityIdentifier("\(prefix).pauseButton.\(suffix)")
+                .id("\(prefix).pauseButton.\(suffix)")
             } else {
                 Button {
                     viewModel.playRecording(recording)
                 } label: {
-                    recordingRowContent(
-                        recording: recording, isToday: isToday,
-                        entry: entry, isPlaying: false)
+                    Image(systemName: "play.fill")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier(identifier)
-                .id(identifier)
+                .accessibilityIdentifier("\(prefix).playButton.\(suffix)")
+                .id("\(prefix).playButton.\(suffix)")
             }
 
-            // Transcribe button alongside the play button so XCTest can locate
-            // it as an independent accessible element.
-            Button {
-                transcriptionTargetRecording = recording
-            } label: {
-                Image(systemName: recording.hasTranscription ? "doc.text.fill" : "doc.text")
-            }
-            .accessibilityIdentifier(
-                isToday
-                    ? "home.transcribeButton.\(recording.sequenceNumber)"
-                    : "past.transcribeButton.\(dateTag(entry!.date)).\(recording.sequenceNumber)"
-            )
-        }
-        .swipeActions(edge: .trailing) {
-            if let targetEntry = isToday ? viewModel.todayEntry : entry {
-                Button(role: .destructive) {
-                    viewModel.deleteRecording(recording, from: targetEntry)
-                } label: {
-                    Label("削除", systemImage: "trash")
+            // Menu button with delete option
+            Menu {
+                if let targetEntry = isToday ? viewModel.todayEntry : entry {
+                    Button(role: .destructive) {
+                        viewModel.deleteRecording(recording, from: targetEntry)
+                    } label: {
+                        Label("削除", systemImage: "trash")
+                    }
+                    .accessibilityIdentifier("\(prefix).deleteMenuItem.\(suffix)")
                 }
-                .accessibilityIdentifier(
-                    isToday
-                        ? "home.deleteButton.\(recording.sequenceNumber)"
-                        : "past.deleteButton.\(dateTag(entry!.date)).\(recording.sequenceNumber)"
-                )
+            } label: {
+                Image(systemName: "ellipsis")
             }
+            .accessibilityIdentifier("\(prefix).moreButton.\(suffix)")
         }
     }
 
     @ViewBuilder
     private func recordingRowContent(
-        recording: Recording, isToday: Bool,
-        entry: JournalEntry?, isPlaying: Bool
+        recording: Recording, isToday: Bool, entry: JournalEntry?
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
@@ -195,7 +183,6 @@ struct HomeView: View {
                 Text(formatDuration(recording.duration))
                     .foregroundStyle(.secondary)
                 Spacer()
-                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
             }
             if let summary = recording.summary {
                 Text(summary)

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct TranscriptionView: View {
     let recording: Recording
+    @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
     var body: some View {
@@ -35,6 +36,16 @@ struct TranscriptionView: View {
             }
             .navigationTitle("書き起こし #\(recording.sequenceNumber)")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityIdentifier("transcription.closeButton")
+                }
+            }
         }
         .task {
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {

--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -71,25 +71,51 @@ final class EntryDetailUITests: XCTestCase {
     }
 
     @MainActor
-    func testSwipeToDelete_removesRecording() throws {
+    func testMenuDelete_removesRecording() throws {
         app.launch()
 
-        // Use descendants query: in iOS 26 SwiftUI List the identifier may appear
-        // on a non-Cell element; descendants finds it regardless of type.
         let recordingRow = app.descendants(matching: .any).matching(
             NSPredicate(format: "identifier == 'home.recordingRow.1'")
         ).firstMatch
         XCTAssertTrue(recordingRow.waitForExistence(timeout: 5))
 
-        // Swipe left to reveal delete action
-        recordingRow.swipeLeft()
-        let deleteButton = app.buttons["削除"]
-        XCTAssertTrue(deleteButton.waitForExistence(timeout: 5))
-        deleteButton.tap()
+        // Tap the more button to open context menu
+        let moreButton = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.moreButton.1'")
+        ).firstMatch
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 5))
+        moreButton.tap()
+
+        // Tap delete menu item
+        let deleteMenuItem = app.buttons["削除"]
+        XCTAssertTrue(deleteMenuItem.waitForExistence(timeout: 5))
+        deleteMenuItem.tap()
 
         // Recording row should disappear
         let rowGone = NSPredicate(format: "exists == false")
         expectation(for: rowGone, evaluatedWith: recordingRow)
         waitForExpectations(timeout: 5)
+    }
+
+    @MainActor
+    func testPlayButton_togglesPlaybackState() throws {
+        app.launch()
+
+        // Play button should exist
+        let playButton = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.playButton.1'")
+        ).firstMatch
+        XCTAssertTrue(playButton.waitForExistence(timeout: 5))
+
+        // Tap play → should switch to pause button
+        playButton.tap()
+        let pauseButton = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.pauseButton.1'")
+        ).firstMatch
+        XCTAssertTrue(pauseButton.waitForExistence(timeout: 5))
+
+        // Tap pause → should switch back to play button
+        pauseButton.tap()
+        XCTAssertTrue(playButton.waitForExistence(timeout: 5))
     }
 }

--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -86,8 +86,10 @@ final class EntryDetailUITests: XCTestCase {
         XCTAssertTrue(moreButton.waitForExistence(timeout: 5))
         moreButton.tap()
 
-        // Tap delete menu item
-        let deleteMenuItem = app.buttons["削除"]
+        // Tap delete menu item (use identifier predicate for robustness)
+        let deleteMenuItem = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.deleteMenuItem.1'")
+        ).firstMatch
         XCTAssertTrue(deleteMenuItem.waitForExistence(timeout: 5))
         deleteMenuItem.tap()
 

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -9,22 +9,22 @@ final class TranscriptionUITests: XCTestCase {
         app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization"]
     }
 
-    // Helper: find the transcribe button regardless of its accessibility type.
-    // In iOS 26 SwiftUI List cells, buttons may not surface as Button type in XCTest;
-    // using descendants with an identifier predicate locates them reliably.
-    private func transcribeButton(index: Int = 1) -> XCUIElement {
+    // Helper: find the recording row regardless of its accessibility type.
+    // In iOS 26 SwiftUI List cells, elements may not surface as expected type
+    // in XCTest; using descendants with an identifier predicate locates them reliably.
+    private func recordingRow(index: Int = 1) -> XCUIElement {
         app.descendants(matching: .any).matching(
-            NSPredicate(format: "identifier == 'home.transcribeButton.\(index)'")
+            NSPredicate(format: "identifier == 'home.recordingRow.\(index)'")
         ).firstMatch
     }
 
     @MainActor
-    func testTranscribeButton_opensTranscriptionSheet() throws {
+    func testRecordingRowTap_opensTranscriptionSheet() throws {
         app.launch()
 
-        let button = transcribeButton()
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
-        button.tap()
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
 
         // Sheet should open and eventually show result text
         let resultText = app.staticTexts["transcription.resultText"]
@@ -35,9 +35,9 @@ final class TranscriptionUITests: XCTestCase {
     func testTranscription_showsResultText() throws {
         app.launch()
 
-        let button = transcribeButton()
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
-        button.tap()
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
 
         let resultText = app.staticTexts["transcription.resultText"]
         XCTAssertTrue(resultText.waitForExistence(timeout: 10))
@@ -48,9 +48,9 @@ final class TranscriptionUITests: XCTestCase {
     func testTranscription_showsSummaryAboveResultText() throws {
         app.launch()
 
-        let button = transcribeButton()
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
-        button.tap()
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
 
         // Summary text should appear above the transcription result
         let summaryText = app.staticTexts["transcription.summaryText"]
@@ -66,9 +66,9 @@ final class TranscriptionUITests: XCTestCase {
     func testTranscription_dismissSheet() throws {
         app.launch()
 
-        let button = transcribeButton()
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
-        button.tap()
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
 
         let resultText = app.staticTexts["transcription.resultText"]
         XCTAssertTrue(resultText.waitForExistence(timeout: 10))
@@ -77,6 +77,6 @@ final class TranscriptionUITests: XCTestCase {
         resultText.swipeDown(velocity: .fast)
 
         // Verify we're back on the home screen
-        XCTAssertTrue(button.waitForExistence(timeout: 5))
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
     }
 }

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -73,8 +73,10 @@ final class TranscriptionUITests: XCTestCase {
         let resultText = app.staticTexts["transcription.resultText"]
         XCTAssertTrue(resultText.waitForExistence(timeout: 10))
 
-        // Swipe down on the result text to dismiss the sheet
-        resultText.swipeDown(velocity: .fast)
+        // Tap the close button to dismiss the sheet
+        let closeButton = app.buttons["transcription.closeButton"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5))
+        closeButton.tap()
 
         // Wait until the transcription sheet is actually dismissed
         let doesNotExistPredicate = NSPredicate(format: "exists == false")

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -76,6 +76,11 @@ final class TranscriptionUITests: XCTestCase {
         // Swipe down on the result text to dismiss the sheet
         resultText.swipeDown(velocity: .fast)
 
+        // Wait until the transcription sheet is actually dismissed
+        let doesNotExistPredicate = NSPredicate(format: "exists == false")
+        expectation(for: doesNotExistPredicate, evaluatedWith: resultText, handler: nil)
+        waitForExpectations(timeout: 5)
+
         // Verify we're back on the home screen
         XCTAssertTrue(row.waitForExistence(timeout: 5))
     }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・14テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・17テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -42,11 +42,13 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `home.dateLabel` — 今日の日付表示（セクションヘッダー）
 - `home.emptyState` — 録音がない場合の空状態テキスト
 - `home.recordButton` — 録音開始ボタン（画面下部固定）
-- `home.recordingRow.{n}` — 今日の録音行（n = sequenceNumber）
-- `home.transcribeButton.{n}` — 今日の録音の書き起こしボタン
+- `home.recordingRow.{n}` — 今日の録音行（n = sequenceNumber）。タップで TranscriptionView へ遷移
+- `home.playButton.{n}` — 今日の録音の再生ボタン（セル右端、非再生時に表示）
+- `home.pauseButton.{n}` — 今日の録音の一時停止ボタン（セル右端、再生中に表示）
+- `home.moreButton.{n}` — 今日の録音のメニューボタン（…アイコン、セル右端）
+- `home.deleteMenuItem.{n}` — メニュー内の削除ボタン（destructive スタイル）
 - `home.transcription.{n}` — 今日の録音セル内の書き起こしテキストプレビュー
 - `home.summary.{n}` — 今日の録音セル内の要約テキストプレビュー（要約がある場合、書き起こしプレビューより優先表示）
-- `home.deleteButton.{n}` — 今日の録音のスワイプ削除ボタン
 - `home.transcriptionSheet` — 書き起こしシート
 - `home.shareButton` — 共有メニューボタン（今日のセクションヘッダー内、録音が存在する場合のみ表示）
 - `home.shareAudioButton` — 共有メニュー内の「音声を共有」ボタン
@@ -58,11 +60,13 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン
 - `past.shareAudioButton.{date}` — 過去の共有メニュー内の「音声を共有」ボタン
 - `past.shareTranscriptButton.{date}` — 過去の共有メニュー内の「テキストを共有」ボタン
-- `past.recordingRow.{date}.{n}` — 過去の録音行
-- `past.transcribeButton.{date}.{n}` — 過去の録音の書き起こしボタン
+- `past.recordingRow.{date}.{n}` — 過去の録音行。タップで TranscriptionView へ遷移
+- `past.playButton.{date}.{n}` — 過去の録音の再生ボタン（セル右端、非再生時に表示）
+- `past.pauseButton.{date}.{n}` — 過去の録音の一時停止ボタン（セル右端、再生中に表示）
+- `past.moreButton.{date}.{n}` — 過去の録音のメニューボタン（…アイコン、セル右端）
+- `past.deleteMenuItem.{date}.{n}` — メニュー内の削除ボタン（destructive スタイル）
 - `past.transcription.{date}.{n}` — 過去の録音セル内の書き起こしテキストプレビュー
 - `past.summary.{date}.{n}` — 過去の録音セル内の要約テキストプレビュー
-- `past.deleteButton.{date}.{n}` — 過去の録音のスワイプ削除ボタン
 
 ### RecordingModalView
 
@@ -89,7 +93,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
 
-## テストケース（5カテゴリ・16テスト）
+## テストケース（5カテゴリ・17テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -130,7 +134,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testSeededHistory_displaysEntries` | シードデータが統合リストに表示される |
 | `testEntryRow_showsDatePreviewAndRecordingInfo` | セルに録音情報が表示される |
 
-### 4. EntryDetailUITests（4テスト）
+### 4. EntryDetailUITests（5テスト）
 
 統合ビュー上で今日の録音に対するテストを実施（旧 EntryDetailView のテストを HomeView に移行）。
 
@@ -139,13 +143,14 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testHomeView_showsDateAndRecordingsList` | 日付と録音リストの表示 |
 | `testShareButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「音声を共有」選択で Activity Sheet 表示 |
 | `testShareTranscriptButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「テキストを共有」選択で Activity Sheet 表示 |
-| `testSwipeToDelete_removesRecording` | スワイプ削除で録音が削除される |
+| `testMenuDelete_removesRecording` | メニューボタン（…）タップ → 削除メニューアイテムタップで録音が削除される |
+| `testPlayButton_togglesPlaybackState` | 再生ボタンタップで一時停止ボタンに切り替わり、一時停止タップで再生ボタンに戻る |
 
 ### 5. TranscriptionUITests（4テスト）
 
 | テスト | 検証内容 |
 |-------|---------|
-| `testTranscribeButton_opensTranscriptionSheet` | 書き起こしボタンタップでモーダル表示・結果テキスト表示 |
+| `testRecordingRowTap_opensTranscriptionSheet` | 録音セルタップで TranscriptionView がモーダル表示され、結果テキストが表示される |
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
 | `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
 | `testTranscription_dismissSheet` | シートをスワイプで閉じてホーム画面に戻る |

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・17テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・16テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -93,7 +93,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
 
-## テストケース（5カテゴリ・17テスト）
+## テストケース（5カテゴリ・16テスト）
 
 ### 1. NavigationUITests（3テスト）
 

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -86,6 +86,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 
 ### TranscriptionView
 
+- `transcription.closeButton` — シートを閉じるボタン（×アイコン、ナビゲーションバー左端）
 - `transcription.loading`
 - `transcription.resultText`
 - `transcription.error`
@@ -153,7 +154,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testRecordingRowTap_opensTranscriptionSheet` | 録音セルタップで TranscriptionView がモーダル表示され、結果テキストが表示される |
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
 | `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
-| `testTranscription_dismissSheet` | シートをスワイプで閉じてホーム画面に戻る |
+| `testTranscription_dismissSheet` | 閉じるボタン（×）をタップしてシートを閉じ、ホーム画面に戻る |
 
 ## テスト対象外（明示的に除外）
 


### PR DESCRIPTION
## Summary

Recording Cell レイアウト変更（Issue #53）に伴い、UITest 設計ドキュメントとテスト実装を更新。

### ドキュメント更新 (`docs/ui-test-design.md`)
- Accessibility Identifier 一覧を最新のレイアウトに合わせて更新
  - 廃止: `transcribeButton`, `deleteButton`（swipe）
  - 追加: `playButton`, `pauseButton`, `moreButton`, `deleteMenuItem`
- テストケース一覧を更新（5カテゴリ・16テスト）

### テスト実装更新
- `EntryDetailUITests`: `testSwipeToDelete` → `testMenuDelete_removesRecording` に置換、`testPlayButton_togglesPlaybackState` を新規追加
- `TranscriptionUITests`: `testTranscribeButton` → `testRecordingRowTap_opensTranscriptionSheet` にリネーム、iOS 26 対応で `descendants` クエリに統一

### View 変更 (`HomeView.swift`)
- Recording Cell のレイアウトを再生ボタン + メニューボタン構成に変更
- 新しい Accessibility Identifier を付与

## Test plan
- [ ] 全 16 UITest が通ること（5カテゴリ: Navigation / HomeRecording / HistoryList / EntryDetail / Transcription）
- [ ] ドキュメントのテスト名・Identifier がテスト実装と一致すること（確認済み）

https://claude.ai/code/session_01DH2BVTE7DqYfC6Jsbmu9zp