### PR TITLE
feat: TranscriptionView に AI プロンプト適用機能を追加

### DIFF
--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -9,6 +9,13 @@ struct SummarizationService {
         return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func applyPrompt(text: String, prompt: String) async throws -> String {
+        let session = LanguageModelSession()
+        let fullPrompt = "\(prompt)\n\n\(text)"
+        let response = try await session.respond(to: fullPrompt)
+        return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     static var isAvailable: Bool {
         if case .available = SystemLanguageModel.default.availability {
             return true

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -20,8 +20,16 @@ final class TranscriptionViewModel {
         case unavailable
     }
 
+    enum PromptState: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+    }
+
     private(set) var state: State = .idle
     private(set) var summaryState: SummaryState = .idle
+    private(set) var promptState: PromptState = .idle
 
     @ObservationIgnored
     var transcribe: (URL, Locale) async throws -> String = TranscriptionService().transcribe
@@ -37,6 +45,8 @@ final class TranscriptionViewModel {
     var summarize: (String) async throws -> String = SummarizationService().summarize
     @ObservationIgnored
     var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
+    @ObservationIgnored
+    var processPrompt: (String, String) async throws -> String = SummarizationService().applyPrompt
 
     func startTranscription(recording: Recording) async {
         // 保存済みの書き起こしがあれば即表示
@@ -78,6 +88,20 @@ final class TranscriptionViewModel {
             }
         } catch {
             state = .failure("書き起こしに失敗しました: \(error.localizedDescription)")
+        }
+    }
+
+    func applyAIPrompt(transcriptionText: String, prompt: String) async {
+        promptState = .loading
+        do {
+            let result = try await processPrompt(transcriptionText, prompt)
+            if result.isEmpty {
+                promptState = .failure("AI結果が空でした。")
+            } else {
+                promptState = .success(result)
+            }
+        } catch {
+            promptState = .failure("AI処理に失敗しました: \(error.localizedDescription)")
         }
     }
 

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -6,6 +6,13 @@ struct TranscriptionView: View {
     let recording: Recording
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
+    @State private var selectedTab: ContentTab = .original
+    @State private var promptText: String = ""
+
+    enum ContentTab: String, CaseIterable {
+        case original = "原文"
+        case aiResult = "AI結果"
+    }
 
     var body: some View {
         NavigationStack {
@@ -15,15 +22,37 @@ struct TranscriptionView: View {
                     ProgressView("書き起こし中...")
                         .accessibilityIdentifier("transcription.loading")
                 case .success(let text):
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 16) {
-                            summarySection
-                            Text(text)
-                                .padding(.horizontal)
-                                .textSelection(.enabled)
-                                .accessibilityIdentifier("transcription.resultText")
+                    VStack(spacing: 0) {
+                        if viewModel.promptState != .idle {
+                            Picker("表示切替", selection: $selectedTab) {
+                                ForEach(ContentTab.allCases, id: \.self) { tab in
+                                    Text(tab.rawValue).tag(tab)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .padding(.horizontal)
+                            .padding(.vertical, 8)
+                            .accessibilityIdentifier("transcription.tabPicker")
                         }
-                        .padding(.vertical)
+
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 16) {
+                                if selectedTab == .original {
+                                    summarySection
+                                    Text(text)
+                                        .padding(.horizontal)
+                                        .textSelection(.enabled)
+                                        .accessibilityIdentifier("transcription.resultText")
+                                } else {
+                                    aiResultSection
+                                }
+                            }
+                            .padding(.vertical)
+                        }
+
+                        if viewModel.isSummarizationAvailable() {
+                            promptBar(transcriptionText: text)
+                        }
                     }
                 case .failure(let message):
                     ContentUnavailableView {
@@ -59,6 +88,13 @@ struct TranscriptionView: View {
                 viewModel.summarize = { text in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
+                }
+                viewModel.isSummarizationAvailable = { true }
+            }
+            if ProcessInfo.processInfo.arguments.contains("--mock-ai-prompt") {
+                viewModel.processPrompt = { text, prompt in
+                    try await Task.sleep(for: .milliseconds(300))
+                    return "これはモックのAI適用結果です。"
                 }
                 viewModel.isSummarizationAvailable = { true }
             }
@@ -106,5 +142,49 @@ struct TranscriptionView: View {
         case .unavailable:
             EmptyView()
         }
+    }
+
+    @ViewBuilder
+    private var aiResultSection: some View {
+        switch viewModel.promptState {
+        case .idle:
+            EmptyView()
+        case .loading:
+            ProgressView("AI処理中...")
+                .padding(.horizontal)
+                .accessibilityIdentifier("transcription.aiResultLoading")
+        case .success(let result):
+            Text(result)
+                .padding(.horizontal)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("transcription.aiResultText")
+        case .failure(let message):
+            Text(message)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+                .accessibilityIdentifier("transcription.aiResultError")
+        }
+    }
+
+    private func promptBar(transcriptionText: String) -> some View {
+        HStack(spacing: 8) {
+            TextField("プロンプトを入力...", text: $promptText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("transcription.promptField")
+            Button("適用") {
+                let currentPrompt = promptText
+                Task {
+                    await viewModel.applyAIPrompt(
+                        transcriptionText: transcriptionText,
+                        prompt: currentPrompt
+                    )
+                    selectedTab = .aiResult
+                }
+            }
+            .disabled(promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.promptState == .loading)
+            .accessibilityIdentifier("transcription.applyButton")
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
     }
 }

--- a/MindEcho/MindEchoTests/AIPromptTests.swift
+++ b/MindEcho/MindEchoTests/AIPromptTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+import MindEchoCore
+@testable import MindEcho
+
+@MainActor
+struct AIPromptTests {
+    private func makeRecording() -> Recording {
+        Recording(
+            sequenceNumber: 1,
+            audioFileName: "20260222_120000.m4a",
+            duration: 10.0,
+            transcription: "テスト書き起こしテキスト"
+        )
+    }
+
+    private func makeViewModel(
+        processPromptResult: String = "AI適用結果テキスト"
+    ) -> TranscriptionViewModel {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in processPromptResult }
+        return vm
+    }
+
+    @Test func initialPromptState_isIdle() {
+        let vm = TranscriptionViewModel()
+        #expect(vm.promptState == .idle)
+    }
+
+    @Test func applyAIPrompt_success() async {
+        let vm = makeViewModel()
+
+        await vm.applyAIPrompt(transcriptionText: "テスト書き起こし", prompt: "要約して")
+
+        #expect(vm.promptState == .success("AI適用結果テキスト"))
+    }
+
+    @Test func applyAIPrompt_emptyResult_failure() async {
+        let vm = makeViewModel(processPromptResult: "")
+
+        await vm.applyAIPrompt(transcriptionText: "テスト書き起こし", prompt: "要約して")
+
+        #expect(vm.promptState == .failure("AI結果が空でした。"))
+    }
+
+    @Test func applyAIPrompt_error_failure() async {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
+        }
+
+        await vm.applyAIPrompt(transcriptionText: "テスト書き起こし", prompt: "要約して")
+
+        if case .failure(let message) = vm.promptState {
+            #expect(message.contains("テストエラー"))
+        } else {
+            Issue.record("Expected failure state")
+        }
+    }
+
+    @Test func applyAIPrompt_doesNotSaveToRecording() async {
+        let vm = makeViewModel()
+        let recording = makeRecording()
+        let originalTranscription = recording.transcription
+        let originalSummary = recording.summary
+
+        await vm.applyAIPrompt(transcriptionText: recording.transcription ?? "", prompt: "要約して")
+
+        #expect(vm.promptState == .success("AI適用結果テキスト"))
+        #expect(recording.transcription == originalTranscription)
+        #expect(recording.summary == originalSummary)
+    }
+
+    @Test func applyAIPrompt_canBeCalledMultipleTimes() async {
+        let vm = TranscriptionViewModel()
+        var callCount = 0
+        vm.processPrompt = { _, _ in
+            callCount += 1
+            return "結果\(callCount)"
+        }
+
+        await vm.applyAIPrompt(transcriptionText: "テキスト", prompt: "プロンプト1")
+        #expect(vm.promptState == .success("結果1"))
+
+        await vm.applyAIPrompt(transcriptionText: "テキスト", prompt: "プロンプト2")
+        #expect(vm.promptState == .success("結果2"))
+
+        #expect(callCount == 2)
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -6,7 +6,7 @@ final class TranscriptionUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization"]
+        app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization", "--mock-ai-prompt"]
     }
 
     // Helper: find the recording row regardless of its accessibility type.
@@ -59,6 +59,83 @@ final class TranscriptionUITests: XCTestCase {
 
         // Result text should also be visible
         let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testAIPrompt_customPrompt_showsResult() throws {
+        app.launch()
+
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        // Wait for transcription result
+        let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 10))
+
+        // Enter prompt text
+        let promptField = app.textFields["transcription.promptField"]
+        XCTAssertTrue(promptField.waitForExistence(timeout: 5))
+        promptField.tap()
+        promptField.typeText("要約して")
+
+        // Tap apply button
+        let applyButton = app.buttons["transcription.applyButton"]
+        XCTAssertTrue(applyButton.waitForExistence(timeout: 5))
+        applyButton.tap()
+
+        // AI result text should appear
+        let aiResultText = app.staticTexts["transcription.aiResultText"]
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 10))
+        XCTAssertTrue(aiResultText.label.contains("モックのAI適用結果"))
+
+        // Segmented picker should be visible
+        let tabPicker = app.segmentedControls["transcription.tabPicker"]
+        XCTAssertTrue(tabPicker.waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testAIPrompt_tabSwitching() throws {
+        app.launch()
+
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        // Wait for transcription result
+        let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 10))
+
+        // Enter prompt and apply
+        let promptField = app.textFields["transcription.promptField"]
+        XCTAssertTrue(promptField.waitForExistence(timeout: 5))
+        promptField.tap()
+        promptField.typeText("要約して")
+
+        let applyButton = app.buttons["transcription.applyButton"]
+        applyButton.tap()
+
+        // Wait for AI result
+        let aiResultText = app.staticTexts["transcription.aiResultText"]
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 10))
+
+        // Switch to original tab
+        let tabPicker = app.segmentedControls["transcription.tabPicker"]
+        XCTAssertTrue(tabPicker.waitForExistence(timeout: 5))
+        tabPicker.buttons["原文"].tap()
+
+        // Original text should be visible
+        XCTAssertTrue(resultText.waitForExistence(timeout: 5))
+
+        // Switch back to AI result tab
+        tabPicker.buttons["AI結果"].tap()
+
+        // AI result text should be visible again
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 5))
+
+        // Switch to original again to confirm it still works
+        tabPicker.buttons["原文"].tap()
         XCTAssertTrue(resultText.waitForExistence(timeout: 5))
     }
 

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・17テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・19テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -15,6 +15,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
 | `--mock-transcription` | TranscriptionView 内の書き起こしクロージャを mock に差し替え（Speech フレームワーク不要でテスト） |
 | `--mock-summarization` | TranscriptionView 内の要約クロージャを mock に差し替え（FoundationModels 不要でテスト） |
+| `--mock-ai-prompt` | TranscriptionView 内の AI プロンプト適用クロージャを mock に差し替え（FoundationModels 不要でテスト） |
 
 ## マイク非依存のテスト方式
 
@@ -97,8 +98,14 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryLoading` — 要約生成中のプログレス表示
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
+- `transcription.tabPicker` — 原文/AI結果セグメントコントロール
+- `transcription.promptField` — プロンプト入力フィールド
+- `transcription.applyButton` — 「適用」ボタン
+- `transcription.aiResultText` — AI処理結果テキスト
+- `transcription.aiResultLoading` — AI処理中プログレス表示
+- `transcription.aiResultError` — AI処理エラーメッセージ
 
-## テストケース（5カテゴリ・16テスト）
+## テストケース（5カテゴリ・18テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -164,13 +171,15 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testMenuDelete_removesRecording` | メニューボタン（…）タップ → 削除メニューアイテムタップで録音が削除される |
 | `testPlayButton_togglesPlaybackState` | 再生ボタンタップで一時停止ボタンに切り替わり、一時停止タップで再生ボタンに戻る |
 
-### 5. TranscriptionUITests（4テスト）
+### 5. TranscriptionUITests（6テスト）
 
 | テスト | 検証内容 |
 |-------|---------|
 | `testRecordingRowTap_opensTranscriptionSheet` | 録音セルタップで TranscriptionView がモーダル表示され、結果テキストが表示される |
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
 | `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
+| `testAIPrompt_customPrompt_showsResult` | プロンプト入力+適用で AI 結果が表示される |
+| `testAIPrompt_tabSwitching` | セグメント切り替えで原文と AI 結果を行き来できる |
 | `testTranscription_dismissSheet` | 閉じるボタン（×）をタップしてシートを閉じ、ホーム画面に戻る |
 
 ## テスト対象外（明示的に除外）


### PR DESCRIPTION
## Summary

- TranscriptionView に Foundation Models を使ったプロンプト適用機能を追加
- ユーザーが任意のプロンプトを入力し「適用」ボタンで AI 処理を実行、セグメント Picker で原文と AI 結果を瞬時に切り替えて比較可能
- プロンプト結果は揮発性（Recording に保存しない）
- Foundation Models 利用不可のデバイスではプロンプト入力バーを非表示

## Changes

| ファイル | 変更種別 |
|---|---|
| `SummarizationService.swift` | `applyPrompt(text:prompt:)` メソッド追加 |
| `TranscriptionViewModel.swift` | `PromptState` enum・`promptState`・`processPrompt` クロージャ・`applyAIPrompt` メソッド追加 |
| `TranscriptionView.swift` | セグメント Picker、プロンプト入力バー、AI 結果表示セクション追加 |
| `AIPromptTests.swift` | 新規作成（6 ユニットテスト） |
| `TranscriptionUITests.swift` | 2 UI テストケース追加（`testAIPrompt_customPrompt_showsResult`, `testAIPrompt_tabSwitching`） |
| `docs/ui-test-design.md` | アクセシビリティ ID・テストケース・launch argument 追記 |

## Test plan

- [ ] `AIPromptTests` の全 6 テストがパスすること
- [ ] `TranscriptionUITests` の全 6 テストがパスすること（既存 4 + 新規 2）
- [ ] 既存の `TranscriptionViewModelTests`・`SummarizationTests` がパスすること
- [ ] Foundation Models 非対応デバイスでプロンプトバーが非表示になること

Closes #65

https://claude.ai/code/session_01UHurDLKomRYo66iVSLjMUw