### PR TITLE
feat: TranscriptionView にTranscriptionView にTranscriptionView にTranscriptionView にTranscriptionView にAIプロンプト適用機能を追加

### DIFF
--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -9,6 +9,13 @@ struct SummarizationService {
         return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func applyPrompt(text: String, prompt: String) async throws -> String {
+        let session = LanguageModelSession()
+        let fullPrompt = "\(prompt)\n\n\(text)"
+        let response = try await session.respond(to: fullPrompt)
+        return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     static var isAvailable: Bool {
         if case .available = SystemLanguageModel.default.availability {
             return true

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -20,8 +20,16 @@ final class TranscriptionViewModel {
         case unavailable
     }
 
+    enum PromptState: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+    }
+
     private(set) var state: State = .idle
     private(set) var summaryState: SummaryState = .idle
+    private(set) var promptState: PromptState = .idle
 
     @ObservationIgnored
     var transcribe: (URL, Locale) async throws -> String = TranscriptionService().transcribe
@@ -37,6 +45,8 @@ final class TranscriptionViewModel {
     var summarize: (String) async throws -> String = SummarizationService().summarize
     @ObservationIgnored
     var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
+    @ObservationIgnored
+    var processPrompt: (String, String) async throws -> String = SummarizationService().applyPrompt
 
     func startTranscription(recording: Recording) async {
         // 保存済みの書き起こしがあれば即表示
@@ -78,6 +88,20 @@ final class TranscriptionViewModel {
             }
         } catch {
             state = .failure("書き起こしに失敗しました: \(error.localizedDescription)")
+        }
+    }
+
+    func applyAIPrompt(transcriptionText: String, prompt: String) async {
+        promptState = .loading
+        do {
+            let result = try await processPrompt(transcriptionText, prompt)
+            if result.isEmpty {
+                promptState = .failure("AI結果が空でした。")
+            } else {
+                promptState = .success(result)
+            }
+        } catch {
+            promptState = .failure("AI処理に失敗しました: \(error.localizedDescription)")
         }
     }
 

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -6,6 +6,13 @@ struct TranscriptionView: View {
     let recording: Recording
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
+    @State private var selectedTab: ContentTab = .original
+    @State private var promptText: String = ""
+
+    private enum ContentTab: Hashable {
+        case original
+        case aiResult
+    }
 
     var body: some View {
         NavigationStack {
@@ -15,15 +22,40 @@ struct TranscriptionView: View {
                     ProgressView("書き起こし中...")
                         .accessibilityIdentifier("transcription.loading")
                 case .success(let text):
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 16) {
-                            summarySection
-                            Text(text)
-                                .padding(.horizontal)
-                                .textSelection(.enabled)
-                                .accessibilityIdentifier("transcription.resultText")
+                    VStack(spacing: 0) {
+                        if viewModel.promptState != .idle {
+                            Picker("表示モード", selection: $selectedTab) {
+                                Text("原文").tag(ContentTab.original)
+                                Text("AI結果").tag(ContentTab.aiResult)
+                            }
+                            .pickerStyle(.segmented)
+                            .padding(.horizontal)
+                            .padding(.vertical, 8)
+                            .accessibilityIdentifier("transcription.tabPicker")
+                            Divider()
                         }
-                        .padding(.vertical)
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 16) {
+                                if selectedTab == .original {
+                                    summarySection
+                                    Text(text)
+                                        .padding(.horizontal)
+                                        .textSelection(.enabled)
+                                        .accessibilityIdentifier("transcription.resultText")
+                                } else {
+                                    aiResultContent
+                                }
+                            }
+                            .padding(.vertical)
+                        }
+                        if viewModel.isSummarizationAvailable() {
+                            promptBar(transcriptionText: text)
+                        }
+                    }
+                    .onChange(of: viewModel.promptState) { _, newState in
+                        if case .success = newState {
+                            selectedTab = .aiResult
+                        }
                     }
                 case .failure(let message):
                     ContentUnavailableView {
@@ -59,6 +91,13 @@ struct TranscriptionView: View {
                 viewModel.summarize = { text in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
+                }
+                viewModel.isSummarizationAvailable = { true }
+            }
+            if ProcessInfo.processInfo.arguments.contains("--mock-ai-prompt") {
+                viewModel.processPrompt = { _, _ in
+                    try await Task.sleep(for: .milliseconds(300))
+                    return "これはモックのAIプロンプト適用結果です。"
                 }
                 viewModel.isSummarizationAvailable = { true }
             }
@@ -105,6 +144,59 @@ struct TranscriptionView: View {
                 .padding(.horizontal)
         case .unavailable:
             EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var aiResultContent: some View {
+        switch viewModel.promptState {
+        case .idle:
+            EmptyView()
+        case .loading:
+            ProgressView("AI処理中...")
+                .frame(maxWidth: .infinity)
+                .padding()
+                .accessibilityIdentifier("transcription.aiResultLoading")
+        case .success(let result):
+            Text(result)
+                .padding(.horizontal)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("transcription.aiResultText")
+        case .failure(let message):
+            VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .accessibilityIdentifier("transcription.aiResultError")
+        }
+    }
+
+    @ViewBuilder
+    private func promptBar(transcriptionText: String) -> some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 8) {
+                TextField("プロンプトを入力...", text: $promptText)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("transcription.promptField")
+                Button("適用") {
+                    let capturedPrompt = promptText
+                    Task {
+                        await viewModel.applyAIPrompt(transcriptionText: transcriptionText, prompt: capturedPrompt)
+                    }
+                }
+                .disabled(promptText.isEmpty || viewModel.promptState == .loading)
+                .accessibilityIdentifier("transcription.applyButton")
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+            .background(.bar)
         }
     }
 }

--- a/MindEcho/MindEchoTests/AIPromptTests.swift
+++ b/MindEcho/MindEchoTests/AIPromptTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+import MindEchoCore
+@testable import MindEcho
+
+@MainActor
+struct AIPromptTests {
+    private func makeRecording() -> Recording {
+        Recording(
+            sequenceNumber: 1,
+            audioFileName: "20260222_120000.m4a",
+            duration: 10.0
+        )
+    }
+
+    @Test func initialPromptState_isIdle() {
+        let vm = TranscriptionViewModel()
+        #expect(vm.promptState == .idle)
+    }
+
+    @Test func applyAIPrompt_success() async {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in "AI適用結果" }
+
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "要約して")
+
+        #expect(vm.promptState == .success("AI適用結果"))
+    }
+
+    @Test func applyAIPrompt_emptyResult_failure() async {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in "" }
+
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "要約して")
+
+        #expect(vm.promptState == .failure("AI結果が空でした。"))
+    }
+
+    @Test func applyAIPrompt_error_failure() async {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
+        }
+
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "要約して")
+
+        if case .failure(let message) = vm.promptState {
+            #expect(message.contains("テストエラー"))
+        } else {
+            Issue.record("Expected failure state")
+        }
+    }
+
+    @Test func applyAIPrompt_doesNotSaveToRecording() async {
+        let vm = TranscriptionViewModel()
+        vm.processPrompt = { _, _ in "AI適用結果" }
+        let recording = makeRecording()
+        recording.transcription = "原文テキスト"
+
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "要約して")
+
+        #expect(recording.transcription == "原文テキスト")
+        #expect(recording.summary == nil)
+    }
+
+    @Test func applyAIPrompt_canBeCalledMultipleTimes() async {
+        let vm = TranscriptionViewModel()
+
+        vm.processPrompt = { _, _ in "1回目の結果" }
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "プロンプト1")
+        #expect(vm.promptState == .success("1回目の結果"))
+
+        vm.processPrompt = { _, _ in "2回目の結果" }
+        await vm.applyAIPrompt(transcriptionText: "原文テキスト", prompt: "プロンプト2")
+        #expect(vm.promptState == .success("2回目の結果"))
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -86,4 +86,80 @@ final class TranscriptionUITests: XCTestCase {
         // Verify we're back on the home screen
         XCTAssertTrue(row.waitForExistence(timeout: 5))
     }
+
+    @MainActor
+    func testAIPrompt_customPrompt_showsResult() throws {
+        app.launchArguments.append("--mock-ai-prompt")
+        app.launch()
+
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        // Wait for transcription to complete
+        let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 10))
+
+        // Enter prompt text
+        let promptField = app.textFields["transcription.promptField"]
+        XCTAssertTrue(promptField.waitForExistence(timeout: 5))
+        promptField.tap()
+        promptField.typeText("要約して")
+
+        // Tap apply button
+        let applyButton = app.buttons["transcription.applyButton"]
+        XCTAssertTrue(applyButton.waitForExistence(timeout: 5))
+        applyButton.tap()
+
+        // AI result text should appear
+        let aiResultText = app.staticTexts["transcription.aiResultText"]
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 10))
+
+        // Segmented picker should appear
+        let tabPicker = app.segmentedControls["transcription.tabPicker"]
+        XCTAssertTrue(tabPicker.exists)
+    }
+
+    @MainActor
+    func testAIPrompt_tabSwitching() throws {
+        app.launchArguments.append("--mock-ai-prompt")
+        app.launch()
+
+        let row = recordingRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.tap()
+
+        // Wait for transcription to complete
+        let resultText = app.staticTexts["transcription.resultText"]
+        XCTAssertTrue(resultText.waitForExistence(timeout: 10))
+
+        // Enter prompt and apply
+        let promptField = app.textFields["transcription.promptField"]
+        XCTAssertTrue(promptField.waitForExistence(timeout: 5))
+        promptField.tap()
+        promptField.typeText("要約して")
+
+        let applyButton = app.buttons["transcription.applyButton"]
+        applyButton.tap()
+
+        // Wait for AI result
+        let aiResultText = app.staticTexts["transcription.aiResultText"]
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 10))
+
+        // Switch to original tab
+        let tabPicker = app.segmentedControls["transcription.tabPicker"]
+        XCTAssertTrue(tabPicker.waitForExistence(timeout: 5))
+        tabPicker.buttons["原文"].tap()
+
+        // Original text should be visible
+        XCTAssertTrue(resultText.waitForExistence(timeout: 5))
+
+        // Switch back to AI result tab
+        tabPicker.buttons["AI結果"].tap()
+        XCTAssertTrue(aiResultText.waitForExistence(timeout: 5))
+
+        // Switch back to original
+        tabPicker.buttons["原文"].tap()
+        XCTAssertTrue(resultText.waitForExistence(timeout: 5))
+    }
 }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -15,6 +15,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
 | `--mock-transcription` | TranscriptionView 内の書き起こしクロージャを mock に差し替え（Speech フレームワーク不要でテスト） |
 | `--mock-summarization` | TranscriptionView 内の要約クロージャを mock に差し替え（FoundationModels 不要でテスト） |
+| `--mock-ai-prompt` | TranscriptionView 内のプロンプト適用クロージャを mock に差し替え（FoundationModels 不要でテスト） |
 
 ## マイク非依存のテスト方式
 
@@ -97,8 +98,14 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryLoading` — 要約生成中のプログレス表示
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
+- `transcription.tabPicker` — 原文/AI結果セグメントコントロール（AI結果生成後に出現）
+- `transcription.promptField` — プロンプト入力フィールド
+- `transcription.applyButton` — 「適用」ボタン
+- `transcription.aiResultText` — AI処理結果テキスト
+- `transcription.aiResultLoading` — AI処理中プログレス表示
+- `transcription.aiResultError` — AI処理エラーメッセージ
 
-## テストケース（5カテゴリ・16テスト）
+## テストケース（5カテゴリ・18テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -164,7 +171,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testMenuDelete_removesRecording` | メニューボタン（…）タップ → 削除メニューアイテムタップで録音が削除される |
 | `testPlayButton_togglesPlaybackState` | 再生ボタンタップで一時停止ボタンに切り替わり、一時停止タップで再生ボタンに戻る |
 
-### 5. TranscriptionUITests（4テスト）
+### 5. TranscriptionUITests（6テスト）
 
 | テスト | 検証内容 |
 |-------|---------|
@@ -172,6 +179,8 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
 | `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
 | `testTranscription_dismissSheet` | 閉じるボタン（×）をタップしてシートを閉じ、ホーム画面に戻る |
+| `testAIPrompt_customPrompt_showsResult` | プロンプト入力+適用でAI結果が表示され、セグメントPickerが出現する |
+| `testAIPrompt_tabSwitching` | セグメント切り替えで原文とAI結果を行き来できる |
 
 ## テスト対象外（明示的に除外）
 


### PR DESCRIPTION
Resolves #65

TranscriptionView に Foundation Model を使ったプロンプト適用機能を追加。ユーザーが任意のプロンプトを適用し、その結果と原文を見比べられる。

Generated with [Claude Code](https://claude.ai/code)