### PR TITLE
feat: 記録がない日付も表示する

### DIFF
--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -69,7 +69,8 @@ struct MindEchoApp: App {
     @MainActor
     private static func seedHistory(context: ModelContext) {
         let calendar = Calendar.current
-        for dayOffset in 1...5 {
+        // Sparse seed data: only 1, 3, 5 days ago (gaps at 2, 4 days ago)
+        for dayOffset in [1, 3, 5] {
             let referenceDate = calendar.date(
                 byAdding: .day,
                 value: -dayOffset,

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -4,6 +4,12 @@ import MindEchoCore
 import Observation
 import SwiftData
 
+struct DateSlot: Identifiable {
+    let date: Date
+    let entry: JournalEntry?
+    var id: Date { date }
+}
+
 @Observable
 class HomeViewModel {
     enum TranscriptionState: Equatable {
@@ -19,6 +25,7 @@ class HomeViewModel {
     var playbackProgress: Double = 0
     var todayEntry: JournalEntry?
     var pastEntries: [JournalEntry] = []
+    var pastDateSlots: [DateSlot] = []
     var errorMessage: String?
     private(set) var transcriptionState: TranscriptionState = .idle
     var recordingTargetDate: Date?
@@ -207,6 +214,23 @@ class HomeViewModel {
         )
         let all = (try? modelContext.fetch(descriptor)) ?? []
         pastEntries = all.filter { $0.date != today }
+
+        // Build pastDateSlots: all dates from oldest entry to yesterday
+        if let oldestDate = all.map(\.date).min() {
+            let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)
+                .map { DateHelper.logicalDate(for: $0) } ?? today
+            if oldestDate < today {
+                let allDates = DateHelper.logicalDateRange(from: oldestDate, to: yesterday)
+                let entryByDate = Dictionary(uniqueKeysWithValues: pastEntries.map { ($0.date, $0) })
+                pastDateSlots = allDates.map { date in
+                    DateSlot(date: date, entry: entryByDate[date])
+                }
+            } else {
+                pastDateSlots = []
+            }
+        } else {
+            pastDateSlots = []
+        }
     }
 
     // MARK: - Recording management
@@ -240,6 +264,9 @@ class HomeViewModel {
 
     private func getOrCreateEntry(for logicalDate: Date) -> JournalEntry {
         if let existing = todayEntry, existing.date == logicalDate {
+            return existing
+        }
+        if let slot = pastDateSlots.first(where: { $0.date == logicalDate }), let existing = slot.entry {
             return existing
         }
         if let existing = pastEntries.first(where: { $0.date == logicalDate }) {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -23,9 +23,9 @@ struct HomeView: View {
                 // Today's section
                 todaySection
 
-                // Past entries sections
-                ForEach(viewModel.pastEntries) { entry in
-                    pastEntrySection(entry)
+                // Past date sections (all dates from oldest entry to yesterday)
+                ForEach(viewModel.pastDateSlots) { slot in
+                    pastDateSection(date: slot.date, entry: slot.entry)
                 }
             }
             .listStyle(.grouped)
@@ -97,21 +97,29 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Past Entry Section
+    // MARK: - Past Date Section
 
     @ViewBuilder
-    private func pastEntrySection(_ entry: JournalEntry) -> some View {
+    private func pastDateSection(date: Date, entry: JournalEntry?) -> some View {
         Section {
-            ForEach(entry.sortedRecordings) { recording in
-                recordingRow(recording, isToday: false, entry: entry)
+            if let entry, !entry.recordings.isEmpty {
+                ForEach(entry.sortedRecordings) { recording in
+                    recordingRow(recording, isToday: false, entry: entry)
+                }
+            } else {
+                Text("録音がありません")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("past.emptyState.\(dateTag(date))")
             }
         } header: {
             HStack {
-                Text(DateHelper.displayString(for: entry.date))
-                    .accessibilityIdentifier("home.sectionHeader.\(dateTag(entry.date))")
+                Text(DateHelper.displayString(for: date))
+                    .accessibilityIdentifier("home.sectionHeader.\(dateTag(date))")
                 Spacer()
-                addMenu(for: entry.date, prefix: "past", dateTag: dateTag(entry.date))
-                shareMenu(for: entry, prefix: "past", dateTag: dateTag(entry.date))
+                addMenu(for: date, prefix: "past", dateTag: dateTag(date))
+                if let entry, !entry.recordings.isEmpty {
+                    shareMenu(for: entry, prefix: "past", dateTag: dateTag(date))
+                }
             }
         }
     }

--- a/MindEcho/MindEchoUITests/Tests/HistoryListUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HistoryListUITests.swift
@@ -27,6 +27,16 @@ final class HistoryListUITests: XCTestCase {
         XCTAssertTrue(entryList.waitForExistence(timeout: 5))
         // Past entries should appear as recording rows
         XCTAssertTrue(entryList.cells.count >= 1)
+
+        // Verify that a date without recordings still has an addButton
+        let calendar = Calendar.current
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: Date())!
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let twoDaysAgoTag = formatter.string(from: twoDaysAgo)
+        let addButton = app.buttons["past.addButton.\(twoDaysAgoTag)"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/MindEcho/MindEchoUITests/Tests/NavigationUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/NavigationUITests.swift
@@ -35,7 +35,20 @@ final class NavigationUITests: XCTestCase {
         // Past entry recordings should be visible in the list
         let entryList = app.collectionViews["home.entryList"]
         XCTAssertTrue(entryList.waitForExistence(timeout: 5))
-        // Should have at least today section + past sections
-        XCTAssertTrue(entryList.cells.count >= 1)
+
+        // With sparse seed data (1, 3, 5 days ago) and all-dates display,
+        // we should have 5 past sections (1-5 days ago) + today section.
+        // Today empty state + 3 recording cells + 2 empty state cells = 6 cells total
+        XCTAssertTrue(entryList.cells.count >= 6)
+
+        // Verify empty state exists for a date without recordings (2 days ago)
+        let calendar = Calendar.current
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: Date())!
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let twoDaysAgoTag = formatter.string(from: twoDaysAgo)
+        let emptyState = app.staticTexts["past.emptyState.\(twoDaysAgoTag)"]
+        XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
     }
 }

--- a/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
@@ -39,4 +39,24 @@ public enum DateHelper {
     public static func today(calendar: Calendar = .current) -> Date {
         logicalDate(for: Date(), calendar: calendar)
     }
+
+    /// Returns an array of logical dates from `from` to `to` (inclusive, descending order).
+    /// Both `from` and `to` should be logical dates (normalized to noon).
+    public static func logicalDateRange(from: Date, to: Date, calendar: Calendar = .current) -> [Date] {
+        var cal = calendar
+        cal.timeZone = TimeZone.current
+        let fromNoon = logicalDate(for: from, calendar: cal)
+        let toNoon = logicalDate(for: to, calendar: cal)
+
+        guard fromNoon <= toNoon else { return [] }
+
+        var dates: [Date] = []
+        var current = toNoon
+        while current >= fromNoon {
+            dates.append(current)
+            guard let prev = cal.date(byAdding: .day, value: -1, to: current) else { break }
+            current = prev
+        }
+        return dates
+    }
 }

--- a/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
+++ b/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
@@ -61,4 +61,56 @@ struct DateHelperTests {
         #expect(display.contains("2"))
         #expect(display.contains("7"))
     }
+
+    // MARK: - logicalDateRange
+
+    @Test func logicalDateRange_returnsDescendingDates() {
+        let from = makeDate(year: 2025, month: 3, day: 1, hour: 12)
+        let to = makeDate(year: 2025, month: 3, day: 5, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        #expect(range.count == 5)
+        let cal = Calendar.current
+        #expect(cal.component(.day, from: range[0]) == 5)
+        #expect(cal.component(.day, from: range[1]) == 4)
+        #expect(cal.component(.day, from: range[2]) == 3)
+        #expect(cal.component(.day, from: range[3]) == 2)
+        #expect(cal.component(.day, from: range[4]) == 1)
+    }
+
+    @Test func logicalDateRange_singleDay() {
+        let date = makeDate(year: 2025, month: 2, day: 10, hour: 12)
+        let range = DateHelper.logicalDateRange(from: date, to: date)
+        #expect(range.count == 1)
+        let cal = Calendar.current
+        #expect(cal.component(.day, from: range[0]) == 10)
+    }
+
+    @Test func logicalDateRange_fromAfterTo_returnsEmpty() {
+        let from = makeDate(year: 2025, month: 3, day: 5, hour: 12)
+        let to = makeDate(year: 2025, month: 3, day: 1, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        #expect(range.isEmpty)
+    }
+
+    @Test func logicalDateRange_normalizesToNoon() {
+        let from = makeDate(year: 2025, month: 3, day: 1, hour: 8)
+        let to = makeDate(year: 2025, month: 3, day: 3, hour: 22)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        let cal = Calendar.current
+        for date in range {
+            #expect(cal.component(.hour, from: date) == 12)
+        }
+    }
+
+    @Test func logicalDateRange_crossesMonthBoundary() {
+        let from = makeDate(year: 2025, month: 1, day: 30, hour: 12)
+        let to = makeDate(year: 2025, month: 2, day: 2, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        #expect(range.count == 4) // Jan 30, 31, Feb 1, 2
+        let cal = Calendar.current
+        #expect(cal.component(.month, from: range[0]) == 2)
+        #expect(cal.component(.day, from: range[0]) == 2)
+        #expect(cal.component(.month, from: range[3]) == 1)
+        #expect(cal.component(.day, from: range[3]) == 30)
+    }
 }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -9,7 +9,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | Launch Argument | 用途 |
 |---|---|
 | `--uitesting` | SwiftData を in-memory ストアに切り替え、テスト毎にクリーンな状態を保証 |
-| `--seed-history` | サンプル JournalEntry データを事前投入（履歴セクションテスト用） |
+| `--seed-history` | サンプル JournalEntry データを歯抜けで事前投入（1日前、3日前、5日前のみ。履歴セクション＋空状態テスト用） |
 | `--seed-today-with-recordings` | 今日のエントリ + モック録音データを事前投入 |
 | `--mock-recorder` | MockAudioRecorderService を注入（マイク不要で録音UI状態遷移をテスト） |
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
@@ -58,8 +58,11 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 
 **過去のセクション**
 
+全日付表示により、最古の JournalEntry.date から今日の前日までの全日付がセクションとして表示される。記録がない日付にも空状態メッセージと追加ボタンが表示される。
+
 - `home.sectionHeader.{date}` — 過去の日付セクションヘッダー（date = yyyyMMdd）
-- `past.addButton.{date}` — 過去のセクションヘッダー内の追加メニューボタン（➕アイコン）
+- `past.emptyState.{date}` — 過去の日付で録音がない場合の空状態テキスト（date = yyyyMMdd）
+- `past.addButton.{date}` — 過去のセクションヘッダー内の追加メニューボタン（➕アイコン、記録がない日付にも表示）
 - `past.recordMenuItem.{date}` — 過去の追加メニュー内の「音声を録音」ボタン
 - `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン
 - `past.shareAudioButton.{date}` — 過去の共有メニュー内の「音声を共有」ボタン
@@ -106,7 +109,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 |-------|---------|
 | `testAppLaunch_showsHomeScreen` | 起動時にホーム画面が表示される |
 | `testAppLaunch_showsTodayEmptyState` | 録音なしで空状態が表示される |
-| `testSeededHistory_showsPastSections` | シードデータで過去のセクションが表示される |
+| `testSeededHistory_showsPastSections` | シードデータで過去の全日付セクション（記録あり・なし含む）が表示される。記録がない日付に `past.emptyState.{date}` が表示されることを検証 |
 
 ### 2. HomeRecordingUITests（2テスト）
 
@@ -149,7 +152,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | テスト | 検証内容 |
 |-------|---------|
 | `testEmptyHistory_showsEmptyState` | データなしで今日のセクションに空状態表示 |
-| `testSeededHistory_displaysEntries` | シードデータが統合リストに表示される |
+| `testSeededHistory_displaysEntries` | シードデータが統合リストに表示される。記録がない日付にも `past.addButton.{date}` が表示されタップ可能であることを検証 |
 | `testEntryRow_showsDatePreviewAndRecordingInfo` | セルに録音情報が表示される |
 
 ### 4. EntryDetailUITests（5テスト）


### PR DESCRIPTION
## Summary
- 最古の JournalEntry.date から今日までの全日付をセクションとして表示
- 記録がない日付には「録音がありません」の空状態メッセージと追加ボタン（➕）を表示
- `JournalEntry` レコードは実際に録音が追加されるまで作成しない（遅延生成を維持）

## Changes
- **DateHelper**: `logicalDateRange(from:to:)` メソッドを追加（指定範囲の論理日付配列を降順で返す）
- **HomeViewModel**: `DateSlot` 構造体と `pastDateSlots` プロパティを追加し、全日付リストを生成
- **HomeView**: 過去セクションを `pastDateSlots` ベースの表示に変更。空状態に `past.emptyState.{date}` を表示
- **MindEchoApp**: シードデータを歯抜け（1日前、3日前、5日前のみ）に変更
- **DateHelperTests**: `logicalDateRange` の Unit テストを5件追加
- **NavigationUITests/HistoryListUITests**: 全日付表示と空状態の検証を追加
- **docs/ui-test-design.md**: Accessibility Identifier 一覧・テストケース説明を更新

## Test plan
- [ ] `xcodebuild build` でビルドが通ること
- [ ] DateHelper の Unit テストが通ること（`logicalDateRange` の5件）
- [ ] NavigationUITests/HistoryListUITests が通ること（空状態検証含む）
- [ ] 記録がない日付に「録音がありません」と➕ボタンが表示されること

Closes #67

https://claude.ai/code/session_01MpRtGiSKKUyXN73NMHUrZG