### PR TITLE
feat: 記録がない日付も過去セクションに表示する (#67)

### DIFF
--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -69,7 +69,8 @@ struct MindEchoApp: App {
     @MainActor
     private static func seedHistory(context: ModelContext) {
         let calendar = Calendar.current
-        for dayOffset in 1...5 {
+        // Use non-consecutive offsets so that "empty" dates (2, 4 days ago) appear in the list
+        for dayOffset in [1, 3, 5] {
             let referenceDate = calendar.date(
                 byAdding: .day,
                 value: -dayOffset,

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -223,7 +223,7 @@ class HomeViewModel {
         let cal = Calendar.current
         let yesterday = cal.date(byAdding: .day, value: -1, to: today) ?? today
         let allDates = DateHelper.logicalDateRange(from: oldestDate, to: yesterday)
-        let entryByDate = Dictionary(uniqueKeysWithValues: past.map { ($0.date, $0) })
+        let entryByDate = Dictionary(past.map { ($0.date, $0) }, uniquingKeysWith: { first, _ in first })
         pastRows = allDates.map { DateRow(date: $0, entry: entryByDate[$0]) }
     }
 

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -13,12 +13,19 @@ class HomeViewModel {
         case failure(String)
     }
 
+    /// Represents a single calendar day in the past section, with an optional entry.
+    struct DateRow: Identifiable {
+        let date: Date
+        let entry: JournalEntry?
+        var id: Date { date }
+    }
+
     var recordingDuration: TimeInterval = 0
     var playingRecordingId: UUID?
     var isPlaying = false
     var playbackProgress: Double = 0
     var todayEntry: JournalEntry?
-    var pastEntries: [JournalEntry] = []
+    var pastRows: [DateRow] = []
     var errorMessage: String?
     private(set) var transcriptionState: TranscriptionState = .idle
     var recordingTargetDate: Date?
@@ -206,7 +213,18 @@ class HomeViewModel {
             sortBy: [SortDescriptor(\.date, order: .reverse)]
         )
         let all = (try? modelContext.fetch(descriptor)) ?? []
-        pastEntries = all.filter { $0.date != today }
+        let past = all.filter { $0.date != today }
+
+        guard let oldestDate = past.last?.date else {
+            pastRows = []
+            return
+        }
+
+        let cal = Calendar.current
+        let yesterday = cal.date(byAdding: .day, value: -1, to: today) ?? today
+        let allDates = DateHelper.logicalDateRange(from: oldestDate, to: yesterday)
+        let entryByDate = Dictionary(uniqueKeysWithValues: past.map { ($0.date, $0) })
+        pastRows = allDates.map { DateRow(date: $0, entry: entryByDate[$0]) }
     }
 
     // MARK: - Recording management
@@ -242,7 +260,7 @@ class HomeViewModel {
         if let existing = todayEntry, existing.date == logicalDate {
             return existing
         }
-        if let existing = pastEntries.first(where: { $0.date == logicalDate }) {
+        if let existing = pastRows.first(where: { $0.date == logicalDate })?.entry {
             return existing
         }
         let descriptor = FetchDescriptor<JournalEntry>(

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -24,8 +24,8 @@ struct HomeView: View {
                 todaySection
 
                 // Past entries sections
-                ForEach(viewModel.pastEntries) { entry in
-                    pastEntrySection(entry)
+                ForEach(viewModel.pastRows) { row in
+                    pastSection(row)
                 }
             }
             .listStyle(.grouped)
@@ -97,21 +97,29 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Past Entry Section
+    // MARK: - Past Section
 
     @ViewBuilder
-    private func pastEntrySection(_ entry: JournalEntry) -> some View {
+    private func pastSection(_ row: HomeViewModel.DateRow) -> some View {
         Section {
-            ForEach(entry.sortedRecordings) { recording in
-                recordingRow(recording, isToday: false, entry: entry)
+            if let entry = row.entry, !entry.recordings.isEmpty {
+                ForEach(entry.sortedRecordings) { recording in
+                    recordingRow(recording, isToday: false, entry: entry)
+                }
+            } else {
+                Text("録音がありません")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("past.emptyState.\(dateTag(row.date))")
             }
         } header: {
             HStack {
-                Text(DateHelper.displayString(for: entry.date))
-                    .accessibilityIdentifier("home.sectionHeader.\(dateTag(entry.date))")
+                Text(DateHelper.displayString(for: row.date))
+                    .accessibilityIdentifier("home.sectionHeader.\(dateTag(row.date))")
                 Spacer()
-                addMenu(for: entry.date, prefix: "past", dateTag: dateTag(entry.date))
-                shareMenu(for: entry, prefix: "past", dateTag: dateTag(entry.date))
+                addMenu(for: row.date, prefix: "past", dateTag: dateTag(row.date))
+                if let entry = row.entry, !entry.recordings.isEmpty {
+                    shareMenu(for: entry, prefix: "past", dateTag: dateTag(row.date))
+                }
             }
         }
     }

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -134,6 +134,52 @@ struct HomeViewModelTests {
         #expect(vm.pastRows.count >= 1)
     }
 
+    @Test func fetchAllEntries_gappedDates_includesMissingDatesWithNilEntry() throws {
+        let schema = Schema([JournalEntry.self, Recording.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let context = container.mainContext
+        let recorder = MockAudioRecorderService()
+        let player = MockAudioPlayerService()
+        let vm = HomeViewModel(modelContext: context, audioRecorder: recorder, audioPlayer: player)
+
+        let cal = Calendar.current
+        let today = DateHelper.logicalDate()
+        // 1・3・5日前にエントリを作成（2・4日前は歯抜け）
+        let daysWithEntries = [-1, -3, -5]
+        var entryDates: [Date] = []
+        for offset in daysWithEntries {
+            let date = cal.date(byAdding: .day, value: offset, to: today)!
+            let logicalDate = DateHelper.logicalDate(for: date)
+            let entry = JournalEntry(date: logicalDate)
+            let recording = Recording(sequenceNumber: 1, audioFileName: "rec\(offset).m4a", duration: 10)
+            entry.recordings.append(recording)
+            context.insert(entry)
+            entryDates.append(logicalDate)
+        }
+
+        vm.fetchAllEntries()
+
+        // 1〜5日前の5行が生成されること
+        #expect(vm.pastRows.count == 5)
+
+        // 1・3・5日前は entry が非 nil
+        for offset in daysWithEntries {
+            let date = DateHelper.logicalDate(for: cal.date(byAdding: .day, value: offset, to: today)!)
+            let row = vm.pastRows.first { $0.date == date }
+            #expect(row != nil, "offset \(offset) の行が存在すること")
+            #expect(row?.entry != nil, "offset \(offset) の行は entry を持つこと")
+        }
+
+        // 2・4日前は entry が nil（歯抜け日付）
+        for offset in [-2, -4] {
+            let date = DateHelper.logicalDate(for: cal.date(byAdding: .day, value: offset, to: today)!)
+            let row = vm.pastRows.first { $0.date == date }
+            #expect(row != nil, "offset \(offset) の行が存在すること")
+            #expect(row?.entry == nil, "offset \(offset) の行は entry を持たないこと")
+        }
+    }
+
     @Test func deleteRecording_removesFromEntry() throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.startRecording()

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -131,7 +131,7 @@ struct HomeViewModelTests {
         vm.fetchAllEntries()
 
         #expect(vm.todayEntry != nil)
-        #expect(vm.pastEntries.count >= 1)
+        #expect(vm.pastRows.count >= 1)
     }
 
     @Test func deleteRecording_removesFromEntry() throws {

--- a/MindEcho/MindEchoUITests/Tests/HistoryListUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HistoryListUITests.swift
@@ -27,6 +27,12 @@ final class HistoryListUITests: XCTestCase {
         XCTAssertTrue(entryList.waitForExistence(timeout: 5))
         // Past entries should appear as recording rows
         XCTAssertTrue(entryList.cells.count >= 1)
+
+        // Add button should exist even for dates without recordings (2 days ago in sparse seed)
+        let addButtonQuery = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'past.addButton.'")
+        )
+        XCTAssertTrue(addButtonQuery.firstMatch.waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/MindEcho/MindEchoUITests/Tests/NavigationUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/NavigationUITests.swift
@@ -37,5 +37,11 @@ final class NavigationUITests: XCTestCase {
         XCTAssertTrue(entryList.waitForExistence(timeout: 5))
         // Should have at least today section + past sections
         XCTAssertTrue(entryList.cells.count >= 1)
+
+        // Dates without recordings (2 and 4 days ago) should show empty state
+        let emptyStateQuery = app.staticTexts.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'past.emptyState.'")
+        )
+        XCTAssertTrue(emptyStateQuery.firstMatch.waitForExistence(timeout: 5))
     }
 }

--- a/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
@@ -39,4 +39,23 @@ public enum DateHelper {
     public static func today(calendar: Calendar = .current) -> Date {
         logicalDate(for: Date(), calendar: calendar)
     }
+
+    /// Returns an array of logical dates from `from` to `to` (both inclusive, descending order).
+    /// Each date is normalized to noon local time using `logicalDate(for:calendar:)`.
+    /// Returns an empty array if `to` is before `from`.
+    public static func logicalDateRange(from: Date, to: Date, calendar: Calendar = .current) -> [Date] {
+        var cal = calendar
+        cal.timeZone = TimeZone.current
+        let fromNoon = logicalDate(for: from, calendar: cal)
+        let toNoon = logicalDate(for: to, calendar: cal)
+
+        guard toNoon >= fromNoon else { return [] }
+
+        let days = cal.dateComponents([.day], from: fromNoon, to: toNoon).day ?? 0
+
+        return (0...days).reversed().compactMap { offset in
+            cal.date(byAdding: .day, value: offset, to: fromNoon)
+                .map { logicalDate(for: $0, calendar: cal) }
+        }
+    }
 }

--- a/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
+++ b/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
@@ -61,4 +61,60 @@ struct DateHelperTests {
         #expect(display.contains("2"))
         #expect(display.contains("7"))
     }
+
+    // MARK: - logicalDateRange
+
+    @Test func logicalDateRange_returnsDescendingDates() {
+        let from = makeDate(year: 2025, month: 2, day: 5, hour: 12)
+        let to = makeDate(year: 2025, month: 2, day: 7, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        let cal = Calendar.current
+
+        #expect(range.count == 3)
+        #expect(cal.component(.day, from: range[0]) == 7)
+        #expect(cal.component(.day, from: range[1]) == 6)
+        #expect(cal.component(.day, from: range[2]) == 5)
+    }
+
+    @Test func logicalDateRange_singleDay() {
+        let date = makeDate(year: 2025, month: 2, day: 7, hour: 12)
+        let range = DateHelper.logicalDateRange(from: date, to: date)
+        let cal = Calendar.current
+
+        #expect(range.count == 1)
+        #expect(cal.component(.day, from: range[0]) == 7)
+    }
+
+    @Test func logicalDateRange_emptyWhenFromAfterTo() {
+        let from = makeDate(year: 2025, month: 2, day: 7, hour: 12)
+        let to = makeDate(year: 2025, month: 2, day: 5, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+
+        #expect(range.isEmpty)
+    }
+
+    @Test func logicalDateRange_allDatesNormalizedToNoon() {
+        let from = makeDate(year: 2025, month: 2, day: 5, hour: 6)
+        let to = makeDate(year: 2025, month: 2, day: 7, hour: 18)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        let cal = Calendar.current
+
+        for date in range {
+            #expect(cal.component(.hour, from: date) == 12)
+            #expect(cal.component(.minute, from: date) == 0)
+        }
+    }
+
+    @Test func logicalDateRange_acrossMonthBoundary() {
+        let from = makeDate(year: 2025, month: 1, day: 30, hour: 12)
+        let to = makeDate(year: 2025, month: 2, day: 1, hour: 12)
+        let range = DateHelper.logicalDateRange(from: from, to: to)
+        let cal = Calendar.current
+
+        #expect(range.count == 3)
+        #expect(cal.component(.day, from: range[0]) == 1)
+        #expect(cal.component(.month, from: range[0]) == 2)
+        #expect(cal.component(.day, from: range[2]) == 30)
+        #expect(cal.component(.month, from: range[2]) == 1)
+    }
 }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -9,7 +9,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | Launch Argument | 用途 |
 |---|---|
 | `--uitesting` | SwiftData を in-memory ストアに切り替え、テスト毎にクリーンな状態を保証 |
-| `--seed-history` | サンプル JournalEntry データを事前投入（履歴セクションテスト用） |
+| `--seed-history` | サンプル JournalEntry データを事前投入（歯抜け：1・3・5日前のみ）。2・4日前は録音なし日付として表示される |
 | `--seed-today-with-recordings` | 今日のエントリ + モック録音データを事前投入 |
 | `--mock-recorder` | MockAudioRecorderService を注入（マイク不要で録音UI状態遷移をテスト） |
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
@@ -59,9 +59,10 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 **過去のセクション**
 
 - `home.sectionHeader.{date}` — 過去の日付セクションヘッダー（date = yyyyMMdd）
-- `past.addButton.{date}` — 過去のセクションヘッダー内の追加メニューボタン（➕アイコン）
+- `past.emptyState.{date}` — 過去の日付で録音がない場合の空状態テキスト（date = yyyyMMdd）
+- `past.addButton.{date}` — 過去のセクションヘッダー内の追加メニューボタン（➕アイコン）。録音がない日付にも表示
 - `past.recordMenuItem.{date}` — 過去の追加メニュー内の「音声を録音」ボタン
-- `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン
+- `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン（録音が存在する場合のみ表示）
 - `past.shareAudioButton.{date}` — 過去の共有メニュー内の「音声を共有」ボタン
 - `past.shareTranscriptButton.{date}` — 過去の共有メニュー内の「テキストを共有」ボタン
 - `past.recordingRow.{date}.{n}` — 過去の録音行。タップで TranscriptionView へ遷移
@@ -106,7 +107,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 |-------|---------|
 | `testAppLaunch_showsHomeScreen` | 起動時にホーム画面が表示される |
 | `testAppLaunch_showsTodayEmptyState` | 録音なしで空状態が表示される |
-| `testSeededHistory_showsPastSections` | シードデータで過去のセクションが表示される |
+| `testSeededHistory_showsPastSections` | シードデータで過去のセクションが表示され、録音がない日付に `past.emptyState.{date}` が表示される |
 
 ### 2. HomeRecordingUITests（2テスト）
 
@@ -149,7 +150,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | テスト | 検証内容 |
 |-------|---------|
 | `testEmptyHistory_showsEmptyState` | データなしで今日のセクションに空状態表示 |
-| `testSeededHistory_displaysEntries` | シードデータが統合リストに表示される |
+| `testSeededHistory_displaysEntries` | シードデータが統合リストに表示され、録音なし日付にも `past.addButton.{date}` が表示される |
 | `testEntryRow_showsDatePreviewAndRecordingInfo` | セルに録音情報が表示される |
 
 ### 4. EntryDetailUITests（5テスト）


### PR DESCRIPTION
- DateHelper に logicalDateRange(from:to:calendar:) メソッドを追加
  - 指定期間内の全論理日付を降順で返す
- HomeViewModel に DateRow 構造体を追加し pastRows へ変更
  - 最古エントリから昨日までの全日付（録音あり/なし問わず）を生成
  - getOrCreateEntry も pastRows を参照するよう更新
- HomeView の過去セクション表示を更新
  - 録音がない日付には「録音がありません」空状態（past.emptyState.{date}）を表示
  - 全日付に addMenu（➕）を表示、共有メニューは録音がある場合のみ表示
- シードデータを歯抜けに変更（1・3・5日前のみ）
  - 2・4日前が録音なし日付として表示されるようにテスト可能にする
- DateHelper テスト: logicalDateRange の単体テスト5件追加
- UITest: NavigationUITests・HistoryListUITests を更新
  - 録音なし日付の空状態・addButton 表示を検証
- docs/ui-test-design.md を更新

## 概要

<!-- このPRで何を変更したか簡潔に記述してください -->

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] ビルド・CI設定の変更
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## 影響範囲

<!-- この変更が影響するファイル・画面・機能を記述してください -->

- 対象画面:
- 対象機能:

## スクリーンショット / 動画

<!-- UI変更がある場合、変更前後のスクリーンショットや動画を添付してください -->

| 変更前 | 変更後 |
|--------|--------|
|        |        |

## テスト

- [ ] ユニットテストを追加・更新した
- [ ] UIテストを追加・更新した
- [ ] シミュレータで動作確認した
- [ ] 実機で動作確認した

## チェックリスト

- [ ] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [ ] 不要なデバッグコード・print文を削除した
- [ ] 既存の機能にデグレがないことを確認した

## 関連Issue

<!-- 関連するIssue番号があればリンクしてください (例: #123) -->

## レビュアーへの補足

<!-- レビュー時に特に見てほしいポイントや注意点があれば記述してください -->
