### PR TITLE
Remove 2-line limit on audio cell text to show full content

### DIFF
--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -207,7 +207,6 @@ struct HomeView: View {
                 Text(summary)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
                     .accessibilityIdentifier(
                         isToday
                             ? "home.summary.\(recording.sequenceNumber)"
@@ -217,7 +216,6 @@ struct HomeView: View {
                 Text(transcription)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
                     .accessibilityIdentifier(
                         isToday
                             ? "home.transcription.\(recording.sequenceNumber)"


### PR DESCRIPTION
Summary and transcription text in recording cells were truncated
at 2 lines. Remove .lineLimit(2) so the cell height adapts to
display the full text.

https://claude.ai/code/session_01W6rKe3NCgCFtoqUCo9oP9T