### PR TITLE
Claude Code Action のモデルを Opus 4.6 に変更

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          model: claude-opus-4-6
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.CLAUDE_CODE_PAT }}
           settings: |


### PR DESCRIPTION
## Summary
- Claude Code Action で使用するモデルを `claude-opus-4-6` に変更
- `.github/workflows/claude.yml` の `with:` ブロックに `model: claude-opus-4-6` を追加

## Test plan
- [ ] GitHub Actions ワークフローの YAML 構文が正しいことを確認
- [ ] 次回 `@claude` メンション時に Opus モデルが使用されることを確認

https://claude.ai/code/session_01XHSANUpBJdZsL9wkdwvQV4