### PR TITLE
feat: 録音画面にリアルタイム書き起こし結果を表示する (#73)

### DIFF
--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -9,12 +9,14 @@ struct MindEchoApp: App {
     private let modelContainer: ModelContainer
     private let audioRecorder: any AudioRecording
     private let audioPlayer: any AudioPlaying
+    private let liveTranscriber: (any LiveTranscribing)?
 
     init() {
         let args = ProcessInfo.processInfo.arguments
         let isUITesting = args.contains("--uitesting")
         let useMockRecorder = args.contains("--mock-recorder")
         let useMockPlayer = args.contains("--mock-player")
+        let useMockLiveTranscription = args.contains("--mock-live-transcription")
         let schema = Schema([
             JournalEntry.self,
             Recording.self,
@@ -41,6 +43,14 @@ struct MindEchoApp: App {
             audioPlayer = AudioPlayerService()
         }
 
+        if useMockLiveTranscription {
+            liveTranscriber = MockLiveTranscriptionService()
+        } else if !isUITesting {
+            liveTranscriber = LiveTranscriptionService()
+        } else {
+            liveTranscriber = nil
+        }
+
         // Seed data for UI testing
         if isUITesting {
             let context = modelContainer.mainContext
@@ -58,7 +68,8 @@ struct MindEchoApp: App {
             HomeView(
                 modelContext: modelContainer.mainContext,
                 audioRecorder: audioRecorder,
-                audioPlayer: audioPlayer
+                audioPlayer: audioPlayer,
+                liveTranscriber: liveTranscriber
             )
         }
         .modelContainer(modelContainer)

--- a/MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift
+++ b/MindEcho/MindEcho/Mocks/MockAudioRecorderService.swift
@@ -1,3 +1,4 @@
+import AVFAudio
 import Foundation
 import MindEchoAudio
 import Observation
@@ -7,6 +8,7 @@ class MockAudioRecorderService: AudioRecording {
     var isRecording = false
     var isPaused = false
     var audioLevels: [Float] = []
+    var onAudioBuffer: ((AVAudioPCMBuffer, AVAudioFormat) -> Void)?
     private(set) var recordingURL: URL?
 
     func startRecording(to url: URL) throws {

--- a/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
@@ -1,9 +1,10 @@
+import AVFAudio
 import Foundation
 import Observation
 
 @Observable
 class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
-    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 // Initial delay must be long enough for XCTest to detect the placeholder state.
@@ -16,6 +17,10 @@ class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                 continuation.finish()
             }
         }
+    }
+
+    func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat) {
+        // No-op for mock — text is emitted on a timer
     }
 
     func stop() {}

--- a/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Observation
+
+@Observable
+class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
+    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                // Initial delay must be long enough for XCTest to detect the placeholder state.
+                try? await Task.sleep(for: .milliseconds(3000))
+                continuation.yield("これは")
+                try? await Task.sleep(for: .milliseconds(300))
+                continuation.yield("これはモックの")
+                try? await Task.sleep(for: .milliseconds(300))
+                continuation.yield("これはモックのリアルタイム書き起こしです。")
+                continuation.finish()
+            }
+        }
+    }
+
+    func stop() {}
+}

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -14,6 +14,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     private var converter: AVAudioConverter?
     private var analyzerFormat: AVAudioFormat?
     private var isSetupComplete = false
+    nonisolated(unsafe) private var lock = os_unfair_lock()
 
     func start(locale: Locale) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
@@ -36,7 +37,10 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                     self.analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
                         compatibleWith: [transcriber]
                     )
-                    self.isSetupComplete = true
+
+                    // Mark setup complete under lock to ensure memory visibility
+                    // for feedAudioBuffer on the audio thread.
+                    self.markSetupComplete()
 
                     // Collect transcription results
                     Task {
@@ -77,7 +81,16 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
         }
     }
 
+    private func markSetupComplete() {
+        os_unfair_lock_lock(&lock)
+        isSetupComplete = true
+        os_unfair_lock_unlock(&lock)
+    }
+
     func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat) {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+
         guard isSetupComplete, let inputContinuation else { return }
 
         if let targetFormat = analyzerFormat {
@@ -120,14 +133,18 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     }
 
     func stop() {
+        os_unfair_lock_lock(&lock)
+        let currentAnalyzer = analyzer
         inputContinuation?.finish()
         inputContinuation = nil
         converter = nil
         analyzerFormat = nil
         isSetupComplete = false
-        Task {
-            try? await analyzer?.finalizeAndFinishThroughEndOfInput()
-        }
         analyzer = nil
+        os_unfair_lock_unlock(&lock)
+
+        Task {
+            try? await currentAnalyzer?.finalizeAndFinishThroughEndOfInput()
+        }
     }
 }

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -1,0 +1,145 @@
+import AVFAudio
+import Foundation
+import Speech
+
+protocol LiveTranscribing: Sendable {
+    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error>
+    func stop()
+}
+
+final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
+    private var analyzer: SpeechAnalyzer?
+    private var audioEngine: AVAudioEngine?
+    private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+
+    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let transcriber = SpeechTranscriber(
+                        locale: locale,
+                        transcriptionOptions: [],
+                        reportingOptions: [.volatileResults],
+                        attributeOptions: []
+                    )
+                    let analyzer = SpeechAnalyzer(modules: [transcriber])
+                    self.analyzer = analyzer
+
+                    // Build input stream
+                    let (inputStream, inputContinuation) = AsyncStream<AnalyzerInput>.makeStream()
+                    self.inputContinuation = inputContinuation
+
+                    // Get best audio format for the analyzer
+                    let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+                        compatibleWith: [transcriber]
+                    )
+
+                    // Set up AVAudioEngine
+                    let audioEngine = AVAudioEngine()
+                    self.audioEngine = audioEngine
+                    let inputNode = audioEngine.inputNode
+                    let hardwareFormat = inputNode.outputFormat(forBus: 0)
+
+                    // Create format converter if needed
+                    let converter: AVAudioConverter?
+                    if let target = analyzerFormat {
+                        converter = AVAudioConverter(from: hardwareFormat, to: target)
+                    } else {
+                        converter = nil
+                    }
+
+                    inputNode.installTap(onBus: 0, bufferSize: 4096, format: hardwareFormat) {
+                        [weak self] buffer, _ in
+                        guard let self else { return }
+                        if let converter, let targetFormat = analyzerFormat {
+                            // Convert to analyzer format
+                            let frameCapacity = AVAudioFrameCount(
+                                Double(buffer.frameLength) * targetFormat.sampleRate
+                                    / hardwareFormat.sampleRate
+                            )
+                            guard
+                                let convertedBuffer = AVAudioPCMBuffer(
+                                    pcmFormat: targetFormat, frameCapacity: frameCapacity)
+                            else { return }
+                            var error: NSError?
+                            converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                                outStatus.pointee = .haveData
+                                return buffer
+                            }
+                            if error == nil {
+                                self.inputContinuation?.yield(AnalyzerInput(buffer: convertedBuffer))
+                            }
+                        } else {
+                            // Copy buffer to avoid reuse issues from installTap
+                            guard
+                                let copy = AVAudioPCMBuffer(
+                                    pcmFormat: hardwareFormat,
+                                    frameCapacity: buffer.frameLength)
+                            else { return }
+                            copy.frameLength = buffer.frameLength
+                            if let src = buffer.floatChannelData,
+                                let dst = copy.floatChannelData
+                            {
+                                for ch in 0..<Int(hardwareFormat.channelCount) {
+                                    dst[ch].update(
+                                        from: src[ch], count: Int(buffer.frameLength))
+                                }
+                            }
+                            self.inputContinuation?.yield(AnalyzerInput(buffer: copy))
+                        }
+                    }
+
+                    // Collect transcription results
+                    Task {
+                        do {
+                            var finalText = ""
+                            for try await result in transcriber.results {
+                                let newText = String(result.text.characters)
+                                if result.isFinal {
+                                    if finalText.isEmpty {
+                                        finalText = newText
+                                    } else {
+                                        finalText += " " + newText
+                                    }
+                                    let combined = finalText
+                                    continuation.yield(combined)
+                                } else {
+                                    // Volatile (partial) result — show final + partial
+                                    let combined: String
+                                    if finalText.isEmpty {
+                                        combined = newText
+                                    } else {
+                                        combined = finalText + " " + newText
+                                    }
+                                    continuation.yield(combined)
+                                }
+                            }
+                            continuation.finish()
+                        } catch {
+                            continuation.finish(throwing: error)
+                        }
+                    }
+
+                    // Start audio engine and analyzer
+                    audioEngine.prepare()
+                    try audioEngine.start()
+                    try await analyzer.start(inputSequence: inputStream)
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    func stop() {
+        inputContinuation?.finish()
+        inputContinuation = nil
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        Task {
+            try? await analyzer?.finalizeAndFinishThroughEndOfInput()
+        }
+        analyzer = nil
+    }
+}

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -3,16 +3,19 @@ import Foundation
 import Speech
 
 protocol LiveTranscribing: Sendable {
-    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error>
+    func start(locale: Locale) -> AsyncThrowingStream<String, Error>
+    func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat)
     func stop()
 }
 
 final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     private var analyzer: SpeechAnalyzer?
-    private var audioEngine: AVAudioEngine?
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+    private var converter: AVAudioConverter?
+    private var analyzerFormat: AVAudioFormat?
+    private var isSetupComplete = false
 
-    func transcriptionStream(locale: Locale) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -30,64 +33,10 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                     self.inputContinuation = inputContinuation
 
                     // Get best audio format for the analyzer
-                    let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+                    self.analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
                         compatibleWith: [transcriber]
                     )
-
-                    // Set up AVAudioEngine
-                    let audioEngine = AVAudioEngine()
-                    self.audioEngine = audioEngine
-                    let inputNode = audioEngine.inputNode
-                    let hardwareFormat = inputNode.outputFormat(forBus: 0)
-
-                    // Create format converter if needed
-                    let converter: AVAudioConverter?
-                    if let target = analyzerFormat {
-                        converter = AVAudioConverter(from: hardwareFormat, to: target)
-                    } else {
-                        converter = nil
-                    }
-
-                    inputNode.installTap(onBus: 0, bufferSize: 4096, format: hardwareFormat) {
-                        [weak self] buffer, _ in
-                        guard let self else { return }
-                        if let converter, let targetFormat = analyzerFormat {
-                            // Convert to analyzer format
-                            let frameCapacity = AVAudioFrameCount(
-                                Double(buffer.frameLength) * targetFormat.sampleRate
-                                    / hardwareFormat.sampleRate
-                            )
-                            guard
-                                let convertedBuffer = AVAudioPCMBuffer(
-                                    pcmFormat: targetFormat, frameCapacity: frameCapacity)
-                            else { return }
-                            var error: NSError?
-                            converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
-                                outStatus.pointee = .haveData
-                                return buffer
-                            }
-                            if error == nil {
-                                self.inputContinuation?.yield(AnalyzerInput(buffer: convertedBuffer))
-                            }
-                        } else {
-                            // Copy buffer to avoid reuse issues from installTap
-                            guard
-                                let copy = AVAudioPCMBuffer(
-                                    pcmFormat: hardwareFormat,
-                                    frameCapacity: buffer.frameLength)
-                            else { return }
-                            copy.frameLength = buffer.frameLength
-                            if let src = buffer.floatChannelData,
-                                let dst = copy.floatChannelData
-                            {
-                                for ch in 0..<Int(hardwareFormat.channelCount) {
-                                    dst[ch].update(
-                                        from: src[ch], count: Int(buffer.frameLength))
-                                }
-                            }
-                            self.inputContinuation?.yield(AnalyzerInput(buffer: copy))
-                        }
-                    }
+                    self.isSetupComplete = true
 
                     // Collect transcription results
                     Task {
@@ -101,8 +50,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                                     } else {
                                         finalText += " " + newText
                                     }
-                                    let combined = finalText
-                                    continuation.yield(combined)
+                                    continuation.yield(finalText)
                                 } else {
                                     // Volatile (partial) result — show final + partial
                                     let combined: String
@@ -120,9 +68,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                         }
                     }
 
-                    // Start audio engine and analyzer
-                    audioEngine.prepare()
-                    try audioEngine.start()
+                    // Start analyzer
                     try await analyzer.start(inputSequence: inputStream)
                 } catch {
                     continuation.finish(throwing: error)
@@ -131,12 +77,54 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
         }
     }
 
+    func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat) {
+        guard isSetupComplete, let inputContinuation else { return }
+
+        if let targetFormat = analyzerFormat {
+            // Create or reuse converter for the source format
+            if converter == nil || converter?.inputFormat != format {
+                converter = AVAudioConverter(from: format, to: targetFormat)
+            }
+            guard let converter else { return }
+
+            let frameCapacity = AVAudioFrameCount(
+                Double(buffer.frameLength) * targetFormat.sampleRate / format.sampleRate
+            )
+            guard
+                let convertedBuffer = AVAudioPCMBuffer(
+                    pcmFormat: targetFormat, frameCapacity: frameCapacity)
+            else { return }
+
+            var error: NSError?
+            converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+            if error == nil {
+                inputContinuation.yield(AnalyzerInput(buffer: convertedBuffer))
+            }
+        } else {
+            // Copy buffer to avoid reuse issues from installTap
+            guard
+                let copy = AVAudioPCMBuffer(
+                    pcmFormat: format, frameCapacity: buffer.frameLength)
+            else { return }
+            copy.frameLength = buffer.frameLength
+            if let src = buffer.floatChannelData, let dst = copy.floatChannelData {
+                for ch in 0..<Int(format.channelCount) {
+                    dst[ch].update(from: src[ch], count: Int(buffer.frameLength))
+                }
+            }
+            inputContinuation.yield(AnalyzerInput(buffer: copy))
+        }
+    }
+
     func stop() {
         inputContinuation?.finish()
         inputContinuation = nil
-        audioEngine?.inputNode.removeTap(onBus: 0)
-        audioEngine?.stop()
-        audioEngine = nil
+        converter = nil
+        analyzerFormat = nil
+        isSetupComplete = false
         Task {
             try? await analyzer?.finalizeAndFinishThroughEndOfInput()
         }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -102,7 +102,7 @@ class HomeViewModel {
         } catch {
             currentRecordingFileName = nil
             currentRecordingStartedAt = nil
-            audioRecorder.onAudioBuffer = nil
+            stopLiveTranscription()
             errorMessage = "録音の開始に失敗しました: \(error.localizedDescription)"
         }
     }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -317,6 +317,8 @@ class HomeViewModel {
                 for try await text in stream {
                     self?.liveTranscriptionText = text
                 }
+            } catch is CancellationError {
+                // ユーザーによる停止操作に伴うキャンセルはエラーとして扱わない
             } catch {
                 self?.liveTranscriptionError = "書き起こしに失敗しました: \(error.localizedDescription)"
             }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -91,15 +91,18 @@ class HomeViewModel {
             let url = FilePathManager.newRecordingURL()
             currentRecordingFileName = url.lastPathComponent
             currentRecordingStartedAt = Date()
+            // Set up live transcription BEFORE starting recorder to avoid
+            // missing initial audio buffers.
+            startLiveTranscription()
             try audioRecorder.startRecording(to: url)
             recordingDuration = 0
             accumulatedDuration = 0
             recordingStartTime = Date()
             startDurationTimer()
-            startLiveTranscription()
         } catch {
             currentRecordingFileName = nil
             currentRecordingStartedAt = nil
+            audioRecorder.onAudioBuffer = nil
             errorMessage = "録音の開始に失敗しました: \(error.localizedDescription)"
         }
     }
@@ -302,7 +305,13 @@ class HomeViewModel {
 
     private func startLiveTranscription() {
         guard let liveTranscriber else { return }
-        let stream = liveTranscriber.transcriptionStream(locale: Locale(identifier: "ja-JP"))
+
+        // Bridge audio buffers from recorder to live transcription service
+        audioRecorder.onAudioBuffer = { buffer, format in
+            liveTranscriber.feedAudioBuffer(buffer, format: format)
+        }
+
+        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"))
         liveTranscriptionTask = Task { @MainActor [weak self] in
             do {
                 for try await text in stream {
@@ -317,6 +326,7 @@ class HomeViewModel {
     private func stopLiveTranscription() {
         liveTranscriptionTask?.cancel()
         liveTranscriptionTask = nil
+        audioRecorder.onAudioBuffer = nil
         liveTranscriber?.stop()
     }
 }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -29,6 +29,8 @@ class HomeViewModel {
     var errorMessage: String?
     private(set) var transcriptionState: TranscriptionState = .idle
     var recordingTargetDate: Date?
+    private(set) var liveTranscriptionText: String = ""
+    private(set) var liveTranscriptionError: String?
 
     @ObservationIgnored
     var transcribe: (URL, Locale) async throws -> String = { url, locale in
@@ -39,6 +41,7 @@ class HomeViewModel {
     private var audioRecorder: any AudioRecording
     private var audioPlayer: any AudioPlaying
     private let exportService: any Exporting
+    private let liveTranscriber: (any LiveTranscribing)?
     private var durationTimer: Timer?
     private var recordingStartTime: Date?
     private var accumulatedDuration: TimeInterval = 0
@@ -46,17 +49,22 @@ class HomeViewModel {
     private var currentRecordingStartedAt: Date?
     private var lastRecordedFileName: String?
     private var lastRecordedRecording: Recording?
+    private var liveTranscriptionTask: Task<Void, Never>?
+
+    var hasLiveTranscription: Bool { liveTranscriber != nil }
 
     init(
         modelContext: ModelContext,
         audioRecorder: any AudioRecording,
         audioPlayer: any AudioPlaying = AudioPlayerService(),
-        exportService: any Exporting = ExportServiceImpl()
+        exportService: any Exporting = ExportServiceImpl(),
+        liveTranscriber: (any LiveTranscribing)? = nil
     ) {
         self.modelContext = modelContext
         self.audioRecorder = audioRecorder
         self.audioPlayer = audioPlayer
         self.exportService = exportService
+        self.liveTranscriber = liveTranscriber
         self.audioPlayer.onPlaybackFinished = { [weak self] in
             self?.isPlaying = false
             self?.playingRecordingId = nil
@@ -76,6 +84,8 @@ class HomeViewModel {
         transcriptionState = .idle
         lastRecordedFileName = nil
         lastRecordedRecording = nil
+        liveTranscriptionText = ""
+        liveTranscriptionError = nil
         do {
             try FilePathManager.ensureDirectoryExists(FilePathManager.recordingsDirectory)
             let url = FilePathManager.newRecordingURL()
@@ -86,6 +96,7 @@ class HomeViewModel {
             accumulatedDuration = 0
             recordingStartTime = Date()
             startDurationTimer()
+            startLiveTranscription()
         } catch {
             currentRecordingFileName = nil
             currentRecordingStartedAt = nil
@@ -109,6 +120,7 @@ class HomeViewModel {
     }
 
     func stopRecording() {
+        stopLiveTranscription()
         if let start = recordingStartTime {
             accumulatedDuration += Date().timeIntervalSince(start)
         }
@@ -284,5 +296,27 @@ class HomeViewModel {
     private func stopDurationTimer() {
         durationTimer?.invalidate()
         durationTimer = nil
+    }
+
+    // MARK: - Live Transcription
+
+    private func startLiveTranscription() {
+        guard let liveTranscriber else { return }
+        let stream = liveTranscriber.transcriptionStream(locale: Locale(identifier: "ja-JP"))
+        liveTranscriptionTask = Task { @MainActor [weak self] in
+            do {
+                for try await text in stream {
+                    self?.liveTranscriptionText = text
+                }
+            } catch {
+                self?.liveTranscriptionError = "書き起こしに失敗しました: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func stopLiveTranscription() {
+        liveTranscriptionTask?.cancel()
+        liveTranscriptionTask = nil
+        liveTranscriber?.stop()
     }
 }

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -9,11 +9,17 @@ struct HomeView: View {
     @State private var isRecordingModalPresented = false
     @State private var shareItems: [Any]?
 
-    init(modelContext: ModelContext, audioRecorder: any AudioRecording, audioPlayer: any AudioPlaying = AudioPlayerService()) {
+    init(
+        modelContext: ModelContext,
+        audioRecorder: any AudioRecording,
+        audioPlayer: any AudioPlaying = AudioPlayerService(),
+        liveTranscriber: (any LiveTranscribing)? = nil
+    ) {
         _viewModel = State(initialValue: HomeViewModel(
             modelContext: modelContext,
             audioRecorder: audioRecorder,
-            audioPlayer: audioPlayer
+            audioPlayer: audioPlayer,
+            liveTranscriber: liveTranscriber
         ))
     }
 

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -59,6 +59,40 @@ struct RecordingModalView: View {
                         }
                         .accessibilityIdentifier("recording.stopButton")
                     }
+
+                    // Live transcription area
+                    if viewModel.hasLiveTranscription {
+                        ScrollViewReader { proxy in
+                            ScrollView {
+                                VStack(alignment: .leading) {
+                                    if let error = viewModel.liveTranscriptionError {
+                                        Text(error)
+                                            .foregroundStyle(.red)
+                                            .accessibilityIdentifier("recording.liveTranscriptionError")
+                                    } else if viewModel.liveTranscriptionText.isEmpty {
+                                        Text("話し始めると書き起こしが表示されます")
+                                            .foregroundStyle(.secondary)
+                                            .accessibilityIdentifier("recording.liveTranscriptionPlaceholder")
+                                    } else {
+                                        Text(viewModel.liveTranscriptionText)
+                                            .accessibilityIdentifier("recording.liveTranscriptionText")
+                                    }
+                                    Color.clear.frame(height: 1).id("bottom")
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding()
+                            }
+                            .frame(maxHeight: 150)
+                            .background(Color(.secondarySystemBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .accessibilityIdentifier("recording.liveTranscription")
+                            .onChange(of: viewModel.liveTranscriptionText) {
+                                withAnimation {
+                                    proxy.scrollTo("bottom", anchor: .bottom)
+                                }
+                            }
+                        }
+                    }
                 } else {
                     // Transcription result area
                     switch viewModel.transcriptionState {

--- a/MindEcho/MindEchoUITests/Tests/LiveTranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/LiveTranscriptionUITests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+final class LiveTranscriptionUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = [
+            "--uitesting",
+            "--mock-recorder",
+            "--mock-live-transcription",
+            "--mock-transcription",
+        ]
+        app.resetAuthorizationStatus(for: .microphone)
+        addUIInterruptionMonitor(withDescription: "Microphone Permission") { alert in
+            let allowButton = alert.buttons["Allow"]
+            if allowButton.exists {
+                allowButton.tap()
+                return true
+            }
+            let allowButtonJa = alert.buttons["許可"]
+            if allowButtonJa.exists {
+                allowButtonJa.tap()
+                return true
+            }
+            return false
+        }
+    }
+
+    @MainActor
+    func testLiveTranscription_flowDuringRecording() throws {
+        app.launch()
+
+        // 1. Tap record button → modal opens + recording starts
+        let recordBtn = app.buttons["home.recordButton"]
+        XCTAssertTrue(recordBtn.waitForExistence(timeout: 5))
+        recordBtn.tap()
+        app.tap()
+
+        // 2. Assert placeholder is shown (initial state)
+        let placeholder = app.staticTexts["recording.liveTranscriptionPlaceholder"]
+        XCTAssertTrue(placeholder.waitForExistence(timeout: 5))
+
+        // 3. Wait for live transcription text to appear (mock emits after 3s initial delay)
+        let liveText = app.staticTexts["recording.liveTranscriptionText"]
+        XCTAssertTrue(liveText.waitForExistence(timeout: 10))
+
+        // 4. Assert placeholder has disappeared
+        XCTAssertFalse(placeholder.exists)
+
+        // 5. Tap stop → recording stops
+        app.buttons["recording.stopButton"].tap()
+
+        // 6. Assert live transcription container is gone
+        let liveContainer = app.otherElements["recording.liveTranscription"]
+        let containerGone = NSPredicate(format: "exists == false")
+        expectation(for: containerGone, evaluatedWith: liveContainer)
+        waitForExpectations(timeout: 5)
+
+        // 7. Assert post-recording transcription result is shown
+        let transcriptionResult = app.staticTexts["recording.transcriptionResult"]
+        XCTAssertTrue(transcriptionResult.waitForExistence(timeout: 10))
+    }
+}

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
@@ -26,6 +26,7 @@ public class AudioRecorderService: AudioRecording {
     public var isRecording = false
     public var isPaused = false
     public var audioLevels: [Float] = []
+    public var onAudioBuffer: ((AVAudioPCMBuffer, AVAudioFormat) -> Void)?
 
     private var audioEngine: AVAudioEngine?
     private var audioFile: AVAudioFile?
@@ -70,6 +71,9 @@ public class AudioRecorderService: AudioRecording {
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
             guard !flag.value else { return }
             try? file.write(from: buffer)
+
+            // Forward buffer to external consumers (e.g., live transcription)
+            self?.onAudioBuffer?(buffer, format)
 
             // Calculate RMS from PCM buffer
             guard let channelData = buffer.floatChannelData?[0] else { return }
@@ -123,6 +127,7 @@ public class AudioRecorderService: AudioRecording {
         isPaused = false
         pauseFlag.value = false
         audioLevels = []
+        onAudioBuffer = nil
 
         try? AVAudioSession.sharedInstance().setActive(false)
     }

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecording.swift
@@ -1,9 +1,11 @@
+import AVFAudio
 import Foundation
 
 public protocol AudioRecording {
     var isRecording: Bool { get }
     var isPaused: Bool { get }
     var audioLevels: [Float] { get }
+    var onAudioBuffer: ((AVAudioPCMBuffer, AVAudioFormat) -> Void)? { get set }
     func startRecording(to url: URL) throws
     func pauseRecording()
     func resumeRecording()

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（5カテゴリ・17テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（6カテゴリ・18テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -15,6 +15,7 @@ UIテストプロセスはアプリと別プロセスで動作するため、lau
 | `--mock-player` | MockAudioPlayerService を注入（実音声ファイル不要で再生UI状態遷移をテスト） |
 | `--mock-transcription` | TranscriptionView 内の書き起こしクロージャを mock に差し替え（Speech フレームワーク不要でテスト） |
 | `--mock-summarization` | TranscriptionView 内の要約クロージャを mock に差し替え（FoundationModels 不要でテスト） |
+| `--mock-live-transcription` | MockLiveTranscriptionService を注入（Speech フレームワーク不要でリアルタイム書き起こしUIをテスト） |
 
 ## マイク非依存のテスト方式
 
@@ -84,6 +85,10 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `recording.pauseButton` — 一時停止ボタン（録音中のみ表示）
 - `recording.resumeButton` — 再開ボタン（一時停止中のみ表示）
 - `recording.stopButton` — 停止ボタン
+- `recording.liveTranscription` — リアルタイム書き起こし ScrollView コンテナ（`liveTranscriber` が注入されている場合のみ表示）
+- `recording.liveTranscriptionText` — リアルタイム書き起こしテキスト（テキストが存在する場合）
+- `recording.liveTranscriptionPlaceholder` — プレースホルダー「話し始めると書き起こしが表示されます」（テキストが空の場合）
+- `recording.liveTranscriptionError` — エラーメッセージ（認識エラー発生時）
 
 **書き起こし後（`viewModel.isRecording == false`）**
 
@@ -99,7 +104,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
 
-## テストケース（5カテゴリ・16テスト）
+## テストケース（6カテゴリ・17テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -173,6 +178,26 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testTranscription_showsResultText` | 書き起こし完了後にモックテキストが表示される |
 | `testTranscription_showsSummaryAboveResultText` | 要約テキストが書き起こしテキストの上に表示される |
 | `testTranscription_dismissSheet` | 閉じるボタン（×）をタップしてシートを閉じ、ホーム画面に戻る |
+
+### 6. LiveTranscriptionUITests（1テスト）
+
+録音中のリアルタイム書き起こし表示フローを検証。
+
+| テスト | 検証内容 |
+|-------|---------|
+| `testLiveTranscription_flowDuringRecording` | プレースホルダー表示 → テキスト更新 → 停止後にリアルタイム書き起こしが消え、録音後書き起こし結果に切り替わる一連のフロー |
+
+**テストステップ:**
+
+1. `home.recordButton` タップ → モーダルが開き録音開始
+2. `recording.liveTranscriptionPlaceholder` が表示されることを確認（初期状態）
+3. `recording.liveTranscriptionText` の出現を待機（timeout: 5秒）— テキスト更新を確認
+4. `recording.liveTranscriptionPlaceholder` が消えていることを確認
+5. `recording.stopButton` タップ → 録音停止
+6. `recording.liveTranscription` が消えていることを確認（`exists == false`）
+7. `recording.transcriptionResult`（既存の録音後書き起こし）が表示されることを確認
+
+**既存テストへの影響:** `HomeRecordingUITests.testRecordingModalFlow` は変更不要。`--mock-live-transcription` を含まないため、リアルタイム書き起こし UI は表示されない。
 
 ## テスト対象外（明示的に除外）
 

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -104,7 +104,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
 
-## テストケース（6カテゴリ・17テスト）
+## テストケース（6カテゴリ・18テスト）
 
 ### 1. NavigationUITests（3テスト）
 


### PR DESCRIPTION
## Summary

- 録音中にリアルタイムの書き起こし結果を表示する機能を追加 (Closes #73)
- `SpeechAnalyzer` + `SpeechTranscriber` API を使用したオンデバイス音声認識
- 録音の一時停止→再開時のクラッシュを修正: `LiveTranscriptionService` が独自の `AVAudioEngine` を作成していたことで2つのエンジンが競合していた問題を解消し、`AudioRecording` プロトコルの `onAudioBuffer` コールバック経由でバッファを共有する設計に変更

## Changes

### New files
- `LiveTranscriptionService.swift` — `LiveTranscribing` プロトコル + `SpeechAnalyzer` 実装
- `MockLiveTranscriptionService.swift` — UIテスト用モック
- `LiveTranscriptionUITests.swift` — リアルタイム書き起こしフローのUIテスト

### Modified files
- `AudioRecording.swift` — `onAudioBuffer` コールバックを追加
- `AudioRecorderService.swift` — タップからバッファを `onAudioBuffer` 経由で転送
- `MockAudioRecorderService.swift` — `onAudioBuffer` プロパティを追加
- `HomeViewModel.swift` — レコーダー→書き起こしのバッファ橋渡し + DI
- `RecordingModalView.swift` — リアルタイム書き起こしUI（ScrollView + 自動スクロール）
- `HomeView.swift` / `MindEchoApp.swift` — DI パススルー
- `docs/ui-test-design.md` — テストケース・Accessibility Identifier 追加

## Test plan

- [x] ビルド成功確認
- [x] `LiveTranscriptionUITests` 合格（プレースホルダー → テキスト更新 → 停止後切り替え）
- [x] `HomeRecordingUITests` 合格（既存テストにリグレッションなし）
- [ ] 実機で録音→一時停止→再開→停止のフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)