### PR TITLE
feat: 録音完了後の書き起こし完了時に要約を自動実行する

### DIFF
--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -174,6 +174,7 @@ class HomeViewModel {
               let recording = lastRecordedRecording else { return }
         let url = FilePathManager.recordingsDirectory.appendingPathComponent(fileName)
         transcriptionState = .loading
+        summaryState = .idle
         do {
             let text = try await transcribe(url, Locale(identifier: "ja-JP"))
             if text.isEmpty {

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -13,13 +13,7 @@ class HomeViewModel {
         case failure(String)
     }
 
-    enum SummaryState: Equatable {
-        case idle
-        case loading
-        case success(String)
-        case failure(String)
-        case unavailable
-    }
+    typealias SummaryState = TranscriptionViewModel.SummaryState
 
     /// Represents a single calendar day in the past section, with an optional entry.
     struct DateRow: Identifiable {
@@ -176,7 +170,8 @@ class HomeViewModel {
     // MARK: - Transcription
 
     func startTranscription() async {
-        guard let fileName = lastRecordedFileName else { return }
+        guard let fileName = lastRecordedFileName,
+              let recording = lastRecordedRecording else { return }
         let url = FilePathManager.recordingsDirectory.appendingPathComponent(fileName)
         transcriptionState = .loading
         do {
@@ -184,11 +179,9 @@ class HomeViewModel {
             if text.isEmpty {
                 transcriptionState = .failure("書き起こし結果が空でした。")
             } else {
-                lastRecordedRecording?.transcription = text
+                recording.transcription = text
                 transcriptionState = .success(text)
-                if let recording = lastRecordedRecording {
-                    await startSummarization(recording: recording, text: text)
-                }
+                await startSummarization(recording: recording, text: text)
             }
         } catch {
             transcriptionState = .failure("書き起こしに失敗しました: \(error.localizedDescription)")

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -13,6 +13,14 @@ class HomeViewModel {
         case failure(String)
     }
 
+    enum SummaryState: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+        case unavailable
+    }
+
     /// Represents a single calendar day in the past section, with an optional entry.
     struct DateRow: Identifiable {
         let date: Date
@@ -28,6 +36,7 @@ class HomeViewModel {
     var pastRows: [DateRow] = []
     var errorMessage: String?
     private(set) var transcriptionState: TranscriptionState = .idle
+    private(set) var summaryState: SummaryState = .idle
     var recordingTargetDate: Date?
     private(set) var liveTranscriptionText: String = ""
     private(set) var liveTranscriptionError: String?
@@ -36,6 +45,10 @@ class HomeViewModel {
     var transcribe: (URL, Locale) async throws -> String = { url, locale in
         try await TranscriptionService().transcribe(audioFileURL: url, locale: locale)
     }
+    @ObservationIgnored
+    var summarize: (String) async throws -> String = SummarizationService().summarize
+    @ObservationIgnored
+    var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
 
     private let modelContext: ModelContext
     private var audioRecorder: any AudioRecording
@@ -173,6 +186,9 @@ class HomeViewModel {
             } else {
                 lastRecordedRecording?.transcription = text
                 transcriptionState = .success(text)
+                if let recording = lastRecordedRecording {
+                    await startSummarization(recording: recording, text: text)
+                }
             }
         } catch {
             transcriptionState = .failure("書き起こしに失敗しました: \(error.localizedDescription)")
@@ -181,8 +197,34 @@ class HomeViewModel {
 
     func resetTranscriptionState() {
         transcriptionState = .idle
+        summaryState = .idle
         lastRecordedFileName = nil
         lastRecordedRecording = nil
+    }
+
+    // MARK: - Summarization
+
+    private func startSummarization(recording: Recording, text: String) async {
+        if let existing = recording.summary {
+            summaryState = .success(existing)
+            return
+        }
+        guard isSummarizationAvailable() else {
+            summaryState = .unavailable
+            return
+        }
+        summaryState = .loading
+        do {
+            let summary = try await summarize(text)
+            if summary.isEmpty {
+                summaryState = .failure("要約結果が空でした。")
+            } else {
+                recording.summary = summary
+                summaryState = .success(summary)
+            }
+        } catch {
+            summaryState = .failure("要約に失敗しました: \(error.localizedDescription)")
+        }
     }
 
     // MARK: - Playback

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -103,10 +103,13 @@ struct RecordingModalView: View {
                             .padding()
                     case .success(let text):
                         ScrollView {
-                            Text(text)
-                                .padding()
-                                .textSelection(.enabled)
-                                .accessibilityIdentifier("recording.transcriptionResult")
+                            VStack(alignment: .leading, spacing: 16) {
+                                summarySectionView
+                                Text(text)
+                                    .padding()
+                                    .textSelection(.enabled)
+                                    .accessibilityIdentifier("recording.transcriptionResult")
+                            }
                         }
                     case .failure(let message):
                         VStack(spacing: 12) {
@@ -140,7 +143,56 @@ struct RecordingModalView: View {
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }
             }
+            if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
+                viewModel.summarize = { _ in
+                    try await Task.sleep(for: .milliseconds(300))
+                    return "これはモックの要約結果です。"
+                }
+                viewModel.isSummarizationAvailable = { true }
+            }
             viewModel.startRecording()
+        }
+    }
+
+    @ViewBuilder
+    private var summarySectionView: some View {
+        switch viewModel.summaryState {
+        case .idle:
+            EmptyView()
+        case .loading:
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                ProgressView("要約を生成中...")
+                    .accessibilityIdentifier("recording.summaryLoading")
+            }
+            .padding(.horizontal)
+        case .success(let summary):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                Text(summary)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier("recording.summaryText")
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+            Divider()
+                .padding(.horizontal)
+        case .failure(let message):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("要約", systemImage: "text.document")
+                    .font(.headline)
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("recording.summaryError")
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+            Divider()
+                .padding(.horizontal)
+        case .unavailable:
+            EmptyView()
         }
     }
 

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -224,6 +224,21 @@ struct HomeViewModelTests {
         #expect(vm.summaryState == .failure("要約結果が空でした。"))
     }
 
+    @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.summarize = { _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
+        vm.isSummarizationAvailable = { true }
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        let recording = vm.todayEntry?.sortedRecordings.first
+        #expect(recording?.summary == nil)
+        #expect(vm.summaryState == .failure("要約に失敗しました: テストエラー"))
+    }
+
     @Test func deleteRecording_removesFromEntry() throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.startRecording()

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -239,6 +239,28 @@ struct HomeViewModelTests {
         #expect(vm.summaryState == .failure("要約に失敗しました: テストエラー"))
     }
 
+    @Test func startTranscription_transcribeThrows_doesNotTriggerSummarization() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        var summarizeCalled = false
+        vm.transcribe = { _, _ in
+            throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
+        }
+        vm.summarize = { _ in
+            summarizeCalled = true
+            return "この要約は呼ばれないはずです"
+        }
+        vm.isSummarizationAvailable = { true }
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        let recording = vm.todayEntry?.sortedRecordings.first
+        #expect(summarizeCalled == false)
+        #expect(recording?.summary == nil)
+        #expect(vm.summaryState == .idle)
+    }
+
     @Test func deleteRecording_removesFromEntry() throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.startRecording()

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -180,6 +180,50 @@ struct HomeViewModelTests {
         }
     }
 
+    @Test func startTranscription_triggersSummarization() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.summarize = { _ in "要約テスト結果" }
+        vm.isSummarizationAvailable = { true }
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        let recording = vm.todayEntry?.sortedRecordings.first
+        #expect(recording?.summary == "要約テスト結果")
+        #expect(vm.summaryState == .success("要約テスト結果"))
+    }
+
+    @Test func startTranscription_summarizationUnavailable_setsUnavailableState() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.isSummarizationAvailable = { false }
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        let recording = vm.todayEntry?.sortedRecordings.first
+        #expect(recording?.summary == nil)
+        #expect(vm.summaryState == .unavailable)
+    }
+
+    @Test func startTranscription_emptySummary_setsFailureState() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.summarize = { _ in "" }
+        vm.isSummarizationAvailable = { true }
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        let recording = vm.todayEntry?.sortedRecordings.first
+        #expect(recording?.summary == nil)
+        #expect(vm.summaryState == .failure("要約結果が空でした。"))
+    }
+
     @Test func deleteRecording_removesFromEntry() throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.startRecording()


### PR DESCRIPTION
## Summary
- 録音完了→書き起こし完了後に `SummarizationService` を自動呼び出しし、要約を生成・SwiftData に保存するように変更
- `RecordingModalView` に要約の表示セクションを追加（ローディング・成功・失敗・利用不可の各状態に対応）
- `HomeViewModel` が `RecordingModalView` より長寿命のため、モーダルを閉じても要約処理は完了・保存される

## Test plan
- [ ] `startTranscription_triggersSummarization`: 書き起こし成功後に要約が実行され `recording.summary` に保存されることを検証
- [ ] `startTranscription_summarizationUnavailable_setsUnavailableState`: 要約利用不可時に `.unavailable` 状態になることを検証
- [ ] `startTranscription_emptySummary_setsFailureState`: 空の要約結果で `.failure` 状態になることを検証
- [ ] 既存の書き起こし関連テストがリグレッションなく通ること
- [ ] macOS 環境で `xcodebuild build` / `xcodebuild test` を実行して確認

https://claude.ai/code/session_01LoMPzhYSmKEBi5EeEawBDg