### PR TITLE
feat: AnalysisContext にユーザー定義語彙を注入して音声認識精度を向上

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `ExportServiceImpl`, `SummarizationService` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `VocabularyView` 等 |
 
 ### Design Principles
 

--- a/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
@@ -4,7 +4,7 @@ import Observation
 
 @Observable
 class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
-    func start(locale: Locale) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = []) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 // Initial delay must be long enough for XCTest to detect the placeholder state.

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -3,7 +3,7 @@ import Foundation
 import Speech
 
 protocol LiveTranscribing: Sendable {
-    func start(locale: Locale) -> AsyncThrowingStream<String, Error>
+    func start(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error>
     func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat)
     func stop()
 }
@@ -16,7 +16,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     private var isSetupComplete = false
     nonisolated(unsafe) private var lock = os_unfair_lock()
 
-    func start(locale: Locale) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = []) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -28,6 +28,14 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                     )
                     let analyzer = SpeechAnalyzer(modules: [transcriber])
                     self.analyzer = analyzer
+
+                    if !contextualStrings.isEmpty {
+                        let context = AnalysisContext()
+                        context.contextualStrings = [
+                            AnalysisContext.ContextualStringsTag("vocabulary"): contextualStrings
+                        ]
+                        try await analyzer.setContext(context)
+                    }
 
                     // Build input stream
                     let (inputStream, inputContinuation) = AsyncStream<AnalyzerInput>.makeStream()

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -3,7 +3,7 @@ import AVFAudio
 import Speech
 
 struct TranscriptionService {
-    func transcribe(audioFileURL: URL, locale: Locale) async throws -> String {
+    func transcribe(audioFileURL: URL, locale: Locale, contextualStrings: [String] = []) async throws -> String {
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
 
         async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in
@@ -11,6 +11,14 @@ struct TranscriptionService {
         }
 
         let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        if !contextualStrings.isEmpty {
+            let context = AnalysisContext()
+            context.contextualStrings = [
+                AnalysisContext.ContextualStringsTag("vocabulary"): contextualStrings
+            ]
+            try await analyzer.setContext(context)
+        }
 
         if let lastSample = try await analyzer.analyzeSequence(
             from: AVAudioFile(forReading: audioFileURL)

--- a/MindEcho/MindEcho/Services/VocabularyStore.swift
+++ b/MindEcho/MindEcho/Services/VocabularyStore.swift
@@ -25,7 +25,9 @@ final class VocabularyStore {
     }
 
     func remove(at offsets: IndexSet) {
-        words.remove(atOffsets: offsets)
+        for index in offsets.sorted().reversed() {
+            words.remove(at: index)
+        }
     }
 
     private func save() {

--- a/MindEcho/MindEcho/Services/VocabularyStore.swift
+++ b/MindEcho/MindEcho/Services/VocabularyStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Observation
+
+@Observable
+final class VocabularyStore {
+    private static let defaultKey = "userVocabulary"
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    var words: [String] {
+        didSet { save() }
+    }
+
+    init(defaults: UserDefaults = .standard, key: String = defaultKey) {
+        self.defaults = defaults
+        self.key = key
+        self.words = defaults.stringArray(forKey: key) ?? []
+    }
+
+    func add(_ word: String) {
+        let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !words.contains(trimmed) else { return }
+        words.append(trimmed)
+    }
+
+    func remove(at offsets: IndexSet) {
+        words.remove(atOffsets: offsets)
+    }
+
+    private func save() {
+        defaults.set(words, forKey: key)
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -34,10 +34,11 @@ class HomeViewModel {
     var recordingTargetDate: Date?
     private(set) var liveTranscriptionText: String = ""
     private(set) var liveTranscriptionError: String?
+    var vocabularyWords: [String] = []
 
     @ObservationIgnored
-    var transcribe: (URL, Locale) async throws -> String = { url, locale in
-        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale)
+    var transcribe: (URL, Locale, [String]) async throws -> String = { url, locale, contextualStrings in
+        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings)
     }
     @ObservationIgnored
     var summarize: (String) async throws -> String = SummarizationService().summarize
@@ -176,7 +177,7 @@ class HomeViewModel {
         transcriptionState = .loading
         summaryState = .idle
         do {
-            let text = try await transcribe(url, Locale(identifier: "ja-JP"))
+            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords)
             if text.isEmpty {
                 transcriptionState = .failure("書き起こし結果が空でした。")
             } else {
@@ -347,7 +348,7 @@ class HomeViewModel {
             liveTranscriber.feedAudioBuffer(buffer, format: format)
         }
 
-        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"))
+        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords)
         liveTranscriptionTask = Task { @MainActor [weak self] in
             do {
                 for try await text in stream {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -22,9 +22,10 @@ final class TranscriptionViewModel {
 
     private(set) var state: State = .idle
     private(set) var summaryState: SummaryState = .idle
+    var vocabularyWords: [String] = []
 
     @ObservationIgnored
-    var transcribe: (URL, Locale) async throws -> String = TranscriptionService().transcribe
+    var transcribe: (URL, Locale, [String]) async throws -> String = TranscriptionService().transcribe
     @ObservationIgnored
     var checkAuthorization: () -> SFSpeechRecognizerAuthorizationStatus = {
         SFSpeechRecognizer.authorizationStatus()
@@ -68,7 +69,7 @@ final class TranscriptionViewModel {
             .appendingPathComponent(recording.audioFileName)
 
         do {
-            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"))
+            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords)
             if text.isEmpty {
                 state = .failure("書き起こし結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -8,6 +8,8 @@ struct HomeView: View {
     @State private var transcriptionTargetRecording: Recording?
     @State private var isRecordingModalPresented = false
     @State private var shareItems: [Any]?
+    @State private var vocabularyStore = VocabularyStore()
+    @State private var showVocabulary = false
 
     init(
         modelContext: ModelContext,
@@ -48,6 +50,16 @@ struct HomeView: View {
                 .padding(.vertical)
             }
             .navigationTitle("MindEcho")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showVocabulary = true
+                    } label: {
+                        Image(systemName: "character.book.closed")
+                    }
+                    .accessibilityIdentifier("home.vocabularyButton")
+                }
+            }
             .sheet(isPresented: Binding(
                 get: { shareItems != nil },
                 set: { if !$0 { shareItems = nil } }
@@ -57,7 +69,14 @@ struct HomeView: View {
                 }
             }
             .onAppear {
+                viewModel.vocabularyWords = vocabularyStore.words
                 viewModel.fetchAllEntries()
+            }
+            .onChange(of: vocabularyStore.words) { _, newWords in
+                viewModel.vocabularyWords = newWords
+            }
+            .sheet(isPresented: $showVocabulary) {
+                VocabularyView(store: vocabularyStore)
             }
             .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
                 if viewModel.isRecording {
@@ -70,7 +89,7 @@ struct HomeView: View {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording)
+                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
         }

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -138,7 +138,7 @@ struct RecordingModalView: View {
         }
         .onAppear {
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _ in
+                viewModel.transcribe = { _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct TranscriptionView: View {
     let recording: Recording
+    var vocabularyWords: [String] = []
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
@@ -48,8 +49,9 @@ struct TranscriptionView: View {
             }
         }
         .task {
+            viewModel.vocabularyWords = vocabularyWords
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _ in
+                viewModel.transcribe = { _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEcho/Views/VocabularyView.swift
+++ b/MindEcho/MindEcho/Views/VocabularyView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct VocabularyView: View {
+    @Bindable var store: VocabularyStore
+    @State private var newWord = ""
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        TextField("単語を入力", text: $newWord)
+                            .accessibilityIdentifier("vocabulary.textField")
+                        Button {
+                            store.add(newWord)
+                            newWord = ""
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                        }
+                        .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .accessibilityIdentifier("vocabulary.addButton")
+                    }
+                }
+
+                Section {
+                    ForEach(Array(store.words.enumerated()), id: \.offset) { index, word in
+                        Text(word)
+                            .accessibilityIdentifier("vocabulary.word.\(index)")
+                    }
+                    .onDelete { offsets in
+                        store.remove(at: offsets)
+                    }
+                }
+                .accessibilityIdentifier("vocabulary.wordList")
+            }
+            .navigationTitle("カスタム語彙")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityIdentifier("vocabulary.closeButton")
+                }
+            }
+        }
+    }
+}

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -84,7 +84,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -96,7 +96,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptyResult_doesNotSave() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "" }
+        vm.transcribe = { _, _, _ in "" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -182,7 +182,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_triggersSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "要約テスト結果" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -197,7 +197,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationUnavailable_setsUnavailableState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
         vm.isSummarizationAvailable = { false }
         vm.startRecording()
         vm.stopRecording()
@@ -211,7 +211,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptySummary_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -226,7 +226,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -242,7 +242,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_transcribeThrows_doesNotTriggerSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         var summarizeCalled = false
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
         }
         vm.summarize = { _ in
@@ -259,6 +259,23 @@ struct HomeViewModelTests {
         #expect(summarizeCalled == false)
         #expect(recording?.summary == nil)
         #expect(vm.summaryState == .idle)
+    }
+
+    @Test func startTranscription_passesVocabularyToTranscribe() async throws {
+        let (vm, _, _, _container) = try makeViewModel()
+        var receivedWords: [String] = []
+        vm.transcribe = { _, _, words in
+            receivedWords = words
+            return "テスト"
+        }
+        vm.isSummarizationAvailable = { false }
+        vm.vocabularyWords = ["MindEcho", "SwiftUI"]
+        vm.startRecording()
+        vm.stopRecording()
+
+        await vm.startTranscription()
+
+        #expect(receivedWords == ["MindEcho", "SwiftUI"])
     }
 
     @Test func deleteRecording_removesFromEntry() throws {

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -27,7 +27,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenSuccess() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             return "テスト書き起こし結果"
         }
@@ -47,7 +47,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _ in "保存されるテキスト" }
+        vm.transcribe = { _, _, _ in "保存されるテキスト" }
 
         let recording = makeRecording()
         #expect(recording.transcription == nil)
@@ -61,7 +61,7 @@ struct TranscriptionViewModelTests {
     @Test func startTranscription_existingTranscription_showsImmediately() async {
         let vm = makeAuthorizedViewModel()
         var transcribeCalled = false
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             transcribeCalled = true
             return "新しいテキスト"
         }
@@ -77,7 +77,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenFailure() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
         }
@@ -101,7 +101,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_emptyResult_showsFailure() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _ in "" }
+        vm.transcribe = { _, _, _ in "" }
 
         let recording = makeRecording()
         await vm.startTranscription(recording: recording)
@@ -111,12 +111,27 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_failure_doesNotSaveTranscription() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
 
         let recording = makeRecording()
         await vm.startTranscription(recording: recording)
         #expect(recording.transcription == nil)
+    }
+
+    @Test func startTranscription_passesVocabularyToTranscribe() async {
+        let vm = makeAuthorizedViewModel()
+        var receivedWords: [String] = []
+        vm.transcribe = { _, _, words in
+            receivedWords = words
+            return "テスト"
+        }
+        vm.vocabularyWords = ["固有名詞", "専門用語"]
+
+        let recording = makeRecording()
+        await vm.startTranscription(recording: recording)
+
+        #expect(receivedWords == ["固有名詞", "専門用語"])
     }
 }

--- a/MindEcho/MindEchoTests/VocabularyStoreTests.swift
+++ b/MindEcho/MindEchoTests/VocabularyStoreTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import MindEcho
+
+@MainActor
+struct VocabularyStoreTests {
+    private func makeStore() -> (VocabularyStore, UserDefaults) {
+        let suiteName = "VocabularyStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let store = VocabularyStore(defaults: defaults)
+        return (store, defaults)
+    }
+
+    @Test func initialState_isEmpty() {
+        let (store, _) = makeStore()
+        #expect(store.words.isEmpty)
+    }
+
+    @Test func add_appendsWord() {
+        let (store, _) = makeStore()
+        store.add("テスト")
+        #expect(store.words == ["テスト"])
+    }
+
+    @Test func add_trimWhitespace() {
+        let (store, _) = makeStore()
+        store.add("  テスト  ")
+        #expect(store.words == ["テスト"])
+    }
+
+    @Test func add_duplicateIsIgnored() {
+        let (store, _) = makeStore()
+        store.add("テスト")
+        store.add("テスト")
+        #expect(store.words == ["テスト"])
+    }
+
+    @Test func add_emptyStringIsIgnored() {
+        let (store, _) = makeStore()
+        store.add("")
+        store.add("   ")
+        #expect(store.words.isEmpty)
+    }
+
+    @Test func remove_deletesAtOffsets() {
+        let (store, _) = makeStore()
+        store.add("A")
+        store.add("B")
+        store.add("C")
+        store.remove(at: IndexSet(integer: 1))
+        #expect(store.words == ["A", "C"])
+    }
+
+    @Test func persistence_roundTrip() {
+        let suiteName = "VocabularyStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+
+        let store1 = VocabularyStore(defaults: defaults)
+        store1.add("永続化テスト")
+
+        let store2 = VocabularyStore(defaults: defaults)
+        #expect(store2.words == ["永続化テスト"])
+    }
+}

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -74,6 +74,18 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `past.transcription.{date}.{n}` — 過去の録音セル内の書き起こしテキストプレビュー
 - `past.summary.{date}.{n}` — 過去の録音セル内の要約テキストプレビュー
 
+**語彙設定**
+
+- `home.vocabularyButton` — ナビゲーションバー右端のカスタム語彙設定ボタン（📖アイコン）
+
+### VocabularyView
+
+- `vocabulary.textField` — 新規単語入力用テキストフィールド
+- `vocabulary.addButton` — 単語追加ボタン（＋アイコン）
+- `vocabulary.wordList` — 登録済み語彙一覧セクション
+- `vocabulary.word.{n}` — 登録済み単語行（n = インデックス）
+- `vocabulary.closeButton` — シートを閉じるボタン（×アイコン）
+
 ### RecordingModalView
 
 録音中はモーダルシートとして表示される。録音中と書き起こし後で表示要素が切り替わる。


### PR DESCRIPTION
## Summary
- `VocabularyStore`（UserDefaults バッキング）と `VocabularyView`（語彙管理 UI）を新規作成
- `TranscriptionService` / `LiveTranscriptionService` に `contextualStrings` パラメータを追加し、`AnalysisContext.contextualStrings` で `SpeechAnalyzer` にユーザー定義語彙のヒントを渡すよう変更
- `HomeViewModel` / `TranscriptionViewModel` のクロージャ型を更新し `vocabularyWords` を伝播。HomeView にツールバーボタンを追加し VocabularyView をシート表示

## Test plan
- [ ] `VocabularyStoreTests` が全パスすること（add / remove / 重複排除 / 永続化）
- [ ] `HomeViewModelTests` が全パスすること（語彙伝播テスト含む）
- [ ] `TranscriptionViewModelTests` が全パスすること（語彙伝播テスト含む）
- [ ] macOS 環境で `xcodebuild build` が成功すること
- [ ] VocabularyView で語彙を追加・削除できることを手動確認
- [ ] 録音→書き起こし時に AnalysisContext が設定されていることをデバッグログで確認

https://claude.ai/code/session_01SFHYaAQvUo51py6ADMc6fU