### PR TITLE
fix: SummarizationTests の transcribe クロージャ引数を修正

### DIFF
--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -23,7 +23,7 @@ struct SummarizationTests {
     ) -> TranscriptionViewModel {
         let vm = TranscriptionViewModel()
         vm.checkAuthorization = { .authorized }
-        vm.transcribe = { _, _ in "テスト書き起こし結果" }
+        vm.transcribe = { _, _, _ in "テスト書き起こし結果" }
         vm.summarize = { _ in summarizeResult }
         vm.isSummarizationAvailable = { available }
         return vm
@@ -123,7 +123,7 @@ struct SummarizationTests {
 
     @Test func transcriptionFailure_doesNotTriggerSummarization() async {
         let vm = makeViewModel()
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
         let recording = makeRecording()


### PR DESCRIPTION
## Summary
- `TranscriptionViewModel.transcribe` のシグネチャが `(URL, Locale, [String])` に変更されたが、`SummarizationTests` のクロージャが2引数 `{ _, _ in ... }` のままだったためビルドエラーが発生
- 26行目と126行目のクロージャを3引数 `{ _, _, _ in ... }` に修正

## Test plan
- [ ] GitHub Actions の Build for Testing ステップが成功することを確認

https://claude.ai/code/session_01H4RfLcXvXMSRgx4xrFZfx9