### PR TITLE
feat: 書き起こしエンジンを設定で切り替え可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `VocabularyView` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `VocabularyView` 等 |
 
 ### Design Principles
 

--- a/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
@@ -4,7 +4,7 @@ import Observation
 
 @Observable
 class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
-    func start(locale: Locale, contextualStrings: [String] = []) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 // Initial delay must be long enough for XCTest to detect the placeholder state.

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -101,7 +101,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
         AsyncThrowingStream { continuation in
             Task {
                 do {
-                    let transcriber = DictationTranscriber(locale: locale)
+                    let transcriber = DictationTranscriber(locale: locale, preset: .progressiveLongDictation)
                     let analyzer = SpeechAnalyzer(modules: [transcriber])
                     self.analyzer = analyzer
 

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -3,9 +3,15 @@ import Foundation
 import Speech
 
 protocol LiveTranscribing: Sendable {
-    func start(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error>
+    func start(locale: Locale, contextualStrings: [String], transcriberType: TranscriberType) -> AsyncThrowingStream<String, Error>
     func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat)
     func stop()
+}
+
+extension LiveTranscribing {
+    func start(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error> {
+        start(locale: locale, contextualStrings: contextualStrings, transcriberType: .speechTranscriber)
+    }
 }
 
 final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
@@ -16,7 +22,16 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     private var isSetupComplete = false
     nonisolated(unsafe) private var lock = os_unfair_lock()
 
-    func start(locale: Locale, contextualStrings: [String] = []) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber) -> AsyncThrowingStream<String, Error> {
+        switch transcriberType {
+        case .speechTranscriber:
+            startWithSpeechTranscriber(locale: locale, contextualStrings: contextualStrings)
+        case .dictationTranscriber:
+            startWithDictationTranscriber(locale: locale, contextualStrings: contextualStrings)
+        }
+    }
+
+    private func startWithSpeechTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -37,20 +52,15 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                         try await analyzer.setContext(context)
                     }
 
-                    // Build input stream
                     let (inputStream, inputContinuation) = AsyncStream<AnalyzerInput>.makeStream()
                     self.inputContinuation = inputContinuation
 
-                    // Get best audio format for the analyzer
                     self.analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
                         compatibleWith: [transcriber]
                     )
 
-                    // Mark setup complete under lock to ensure memory visibility
-                    // for feedAudioBuffer on the audio thread.
                     self.markSetupComplete()
 
-                    // Collect transcription results
                     Task {
                         do {
                             var finalText = ""
@@ -64,7 +74,6 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                                     }
                                     continuation.yield(finalText)
                                 } else {
-                                    // Volatile (partial) result — show final + partial
                                     let combined: String
                                     if finalText.isEmpty {
                                         combined = newText
@@ -80,7 +89,67 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
                         }
                     }
 
-                    // Start analyzer
+                    try await analyzer.start(inputSequence: inputStream)
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func startWithDictationTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let transcriber = DictationTranscriber(locale: locale)
+                    let analyzer = SpeechAnalyzer(modules: [transcriber])
+                    self.analyzer = analyzer
+
+                    if !contextualStrings.isEmpty {
+                        let context = AnalysisContext()
+                        context.contextualStrings = [
+                            AnalysisContext.ContextualStringsTag("vocabulary"): contextualStrings
+                        ]
+                        try await analyzer.setContext(context)
+                    }
+
+                    let (inputStream, inputContinuation) = AsyncStream<AnalyzerInput>.makeStream()
+                    self.inputContinuation = inputContinuation
+
+                    self.analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+                        compatibleWith: [transcriber]
+                    )
+
+                    self.markSetupComplete()
+
+                    Task {
+                        do {
+                            var finalText = ""
+                            for try await result in transcriber.results {
+                                let newText = String(result.text.characters)
+                                if result.isFinal {
+                                    if finalText.isEmpty {
+                                        finalText = newText
+                                    } else {
+                                        finalText += " " + newText
+                                    }
+                                    continuation.yield(finalText)
+                                } else {
+                                    let combined: String
+                                    if finalText.isEmpty {
+                                        combined = newText
+                                    } else {
+                                        combined = finalText + " " + newText
+                                    }
+                                    continuation.yield(combined)
+                                }
+                            }
+                            continuation.finish()
+                        } catch {
+                            continuation.finish(throwing: error)
+                        }
+                    }
+
                     try await analyzer.start(inputSequence: inputStream)
                 } catch {
                     continuation.finish(throwing: error)

--- a/MindEcho/MindEcho/Services/TranscriberPreference.swift
+++ b/MindEcho/MindEcho/Services/TranscriberPreference.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Observation
+
+enum TranscriberType: String, CaseIterable, Sendable {
+    case speechTranscriber
+    case dictationTranscriber
+
+    var displayName: String {
+        switch self {
+        case .speechTranscriber:
+            "SpeechTranscriber"
+        case .dictationTranscriber:
+            "DictationTranscriber"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .speechTranscriber:
+            "高精度・生テキスト出力"
+        case .dictationTranscriber:
+            "句読点付き・カスタム語彙対応"
+        }
+    }
+}
+
+@Observable
+final class TranscriberPreference {
+    private static let defaultKey = "transcriberType"
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    var type: TranscriberType {
+        didSet { save() }
+    }
+
+    init(defaults: UserDefaults = .standard, key: String = defaultKey) {
+        self.defaults = defaults
+        self.key = key
+        let raw = defaults.string(forKey: key) ?? ""
+        self.type = TranscriberType(rawValue: raw) ?? .speechTranscriber
+    }
+
+    private func save() {
+        defaults.set(type.rawValue, forKey: key)
+    }
+}

--- a/MindEcho/MindEcho/Services/TranscriberPreference.swift
+++ b/MindEcho/MindEcho/Services/TranscriberPreference.swift
@@ -19,7 +19,7 @@ enum TranscriberType: String, CaseIterable, Sendable {
         case .speechTranscriber:
             "高精度・生テキスト出力"
         case .dictationTranscriber:
-            "句読点付き・カスタム語彙対応"
+            "句読点付き出力"
         }
     }
 }

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -3,8 +3,51 @@ import AVFAudio
 import Speech
 
 struct TranscriptionService {
-    func transcribe(audioFileURL: URL, locale: Locale, contextualStrings: [String] = []) async throws -> String {
+    func transcribe(
+        audioFileURL: URL,
+        locale: Locale,
+        contextualStrings: [String] = [],
+        transcriberType: TranscriberType = .speechTranscriber
+    ) async throws -> String {
+        switch transcriberType {
+        case .speechTranscriber:
+            try await transcribeWithSpeech(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
+        case .dictationTranscriber:
+            try await transcribeWithDictation(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
+        }
+    }
+
+    private func transcribeWithSpeech(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws -> String {
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+
+        async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in
+            partialResult + String(result.text.characters) + " "
+        }
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+        if !contextualStrings.isEmpty {
+            let context = AnalysisContext()
+            context.contextualStrings = [
+                AnalysisContext.ContextualStringsTag("vocabulary"): contextualStrings
+            ]
+            try await analyzer.setContext(context)
+        }
+
+        if let lastSample = try await analyzer.analyzeSequence(
+            from: AVAudioFile(forReading: audioFileURL)
+        ) {
+            try await analyzer.finalizeAndFinish(through: lastSample)
+        } else {
+            await analyzer.cancelAndFinishNow()
+        }
+
+        let resultText = await transcriptionFuture
+        return resultText.trimmingCharacters(in: CharacterSet.whitespaces)
+    }
+
+    private func transcribeWithDictation(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws -> String {
+        let transcriber = DictationTranscriber(locale: locale)
 
         async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in
             partialResult + String(result.text.characters) + " "

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -47,7 +47,7 @@ struct TranscriptionService {
     }
 
     private func transcribeWithDictation(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws -> String {
-        let transcriber = DictationTranscriber(locale: locale)
+        let transcriber = DictationTranscriber(locale: locale, preset: .longDictation)
 
         async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in
             partialResult + String(result.text.characters) + " "

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -35,10 +35,11 @@ class HomeViewModel {
     private(set) var liveTranscriptionText: String = ""
     private(set) var liveTranscriptionError: String?
     var vocabularyWords: [String] = []
+    var transcriberType: TranscriberType = .speechTranscriber
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String]) async throws -> String = { url, locale, contextualStrings in
-        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings)
+    var transcribe: (URL, Locale, [String], TranscriberType) async throws -> String = { url, locale, contextualStrings, transcriberType in
+        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType)
     }
     @ObservationIgnored
     var summarize: (String) async throws -> String = SummarizationService().summarize
@@ -177,7 +178,7 @@ class HomeViewModel {
         transcriptionState = .loading
         summaryState = .idle
         do {
-            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords)
+            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType)
             if text.isEmpty {
                 transcriptionState = .failure("書き起こし結果が空でした。")
             } else {
@@ -348,7 +349,7 @@ class HomeViewModel {
             liveTranscriber.feedAudioBuffer(buffer, format: format)
         }
 
-        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords)
+        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords, transcriberType: transcriberType)
         liveTranscriptionTask = Task { @MainActor [weak self] in
             do {
                 for try await text in stream {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -40,6 +40,13 @@ final class TranscriptionViewModel {
     @ObservationIgnored
     var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
 
+    func retryTranscription(recording: Recording) async {
+        recording.transcription = nil
+        recording.summary = nil
+        summaryState = .idle
+        await startTranscription(recording: recording)
+    }
+
     func startTranscription(recording: Recording) async {
         // 保存済みの書き起こしがあれば即表示
         if let existing = recording.transcription {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -23,9 +23,10 @@ final class TranscriptionViewModel {
     private(set) var state: State = .idle
     private(set) var summaryState: SummaryState = .idle
     var vocabularyWords: [String] = []
+    var transcriberType: TranscriberType = .speechTranscriber
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String]) async throws -> String = TranscriptionService().transcribe
+    var transcribe: (URL, Locale, [String], TranscriberType) async throws -> String = TranscriptionService().transcribe
     @ObservationIgnored
     var checkAuthorization: () -> SFSpeechRecognizerAuthorizationStatus = {
         SFSpeechRecognizer.authorizationStatus()
@@ -69,7 +70,7 @@ final class TranscriptionViewModel {
             .appendingPathComponent(recording.audioFileName)
 
         do {
-            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords)
+            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType)
             if text.isEmpty {
                 state = .failure("書き起こし結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -61,6 +61,7 @@ struct HomeView: View {
                             Image(systemName: "gearshape")
                         }
                         .accessibilityIdentifier("home.settingsButton")
+                        .accessibilityLabel("設定")
 
                         Button {
                             showVocabulary = true
@@ -68,6 +69,7 @@ struct HomeView: View {
                             Image(systemName: "character.book.closed")
                         }
                         .accessibilityIdentifier("home.vocabularyButton")
+                        .accessibilityLabel("語彙")
                     }
                 }
             }

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -9,7 +9,9 @@ struct HomeView: View {
     @State private var isRecordingModalPresented = false
     @State private var shareItems: [Any]?
     @State private var vocabularyStore = VocabularyStore()
+    @State private var transcriberPreference = TranscriberPreference()
     @State private var showVocabulary = false
+    @State private var showSettings = false
 
     init(
         modelContext: ModelContext,
@@ -52,12 +54,21 @@ struct HomeView: View {
             .navigationTitle("MindEcho")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showVocabulary = true
-                    } label: {
-                        Image(systemName: "character.book.closed")
+                    HStack(spacing: 16) {
+                        Button {
+                            showSettings = true
+                        } label: {
+                            Image(systemName: "gearshape")
+                        }
+                        .accessibilityIdentifier("home.settingsButton")
+
+                        Button {
+                            showVocabulary = true
+                        } label: {
+                            Image(systemName: "character.book.closed")
+                        }
+                        .accessibilityIdentifier("home.vocabularyButton")
                     }
-                    .accessibilityIdentifier("home.vocabularyButton")
                 }
             }
             .sheet(isPresented: Binding(
@@ -70,13 +81,20 @@ struct HomeView: View {
             }
             .onAppear {
                 viewModel.vocabularyWords = vocabularyStore.words
+                viewModel.transcriberType = transcriberPreference.type
                 viewModel.fetchAllEntries()
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
                 viewModel.vocabularyWords = newWords
             }
+            .onChange(of: transcriberPreference.type) { _, newType in
+                viewModel.transcriberType = newType
+            }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView(transcriberPreference: transcriberPreference)
             }
             .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
                 if viewModel.isRecording {
@@ -89,7 +107,7 @@ struct HomeView: View {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words)
+                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.type)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
         }

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -138,7 +138,7 @@ struct RecordingModalView: View {
         }
         .onAppear {
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _, _ in
+                viewModel.transcribe = { _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
                 } header: {
                     Text("書き起こしエンジン")
                 } footer: {
-                    Text("SpeechTranscriber は高精度ですがカスタム語彙が効きません。DictationTranscriber は句読点付きの出力でカスタム語彙に対応しています。")
+                    Text("SpeechTranscriber は高精度な生テキスト出力に対応しています。DictationTranscriber は句読点付きの出力に対応しています。どちらもカスタム語彙を利用できます。")
                 }
             }
             .navigationTitle("設定")

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Bindable var transcriberPreference: TranscriberPreference
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(TranscriberType.allCases, id: \.self) { type in
+                        Button {
+                            transcriberPreference.type = type
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(type.displayName)
+                                        .foregroundStyle(.primary)
+                                    Text(type.description)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                if transcriberPreference.type == type {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(.blue)
+                                }
+                            }
+                        }
+                        .accessibilityIdentifier("settings.transcriber.\(type.rawValue)")
+                    }
+                } header: {
+                    Text("書き起こしエンジン")
+                } footer: {
+                    Text("SpeechTranscriber は高精度ですがカスタム語彙が効きません。DictationTranscriber は句読点付きの出力でカスタム語彙に対応しています。")
+                }
+            }
+            .navigationTitle("設定")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityIdentifier("settings.closeButton")
+                }
+            }
+        }
+    }
+}

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -47,6 +47,16 @@ struct TranscriptionView: View {
                     }
                     .accessibilityIdentifier("transcription.closeButton")
                 }
+                if case .success = viewModel.state {
+                    ToolbarItem(placement: .primaryAction) {
+                        retryButton
+                    }
+                }
+                if case .failure = viewModel.state {
+                    ToolbarItem(placement: .primaryAction) {
+                        retryButton
+                    }
+                }
             }
         }
         .task {
@@ -68,6 +78,18 @@ struct TranscriptionView: View {
             }
             await viewModel.startTranscription(recording: recording)
         }
+    }
+
+    private var retryButton: some View {
+        Button {
+            viewModel.transcriberType = transcriberType
+            Task {
+                await viewModel.retryTranscription(recording: recording)
+            }
+        } label: {
+            Image(systemName: "arrow.clockwise")
+        }
+        .accessibilityIdentifier("transcription.retryButton")
     }
 
     @ViewBuilder

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -51,8 +51,7 @@ struct TranscriptionView: View {
                     ToolbarItem(placement: .primaryAction) {
                         retryButton
                     }
-                }
-                if case .failure = viewModel.state {
+                } else if case .failure = viewModel.state {
                     ToolbarItem(placement: .primaryAction) {
                         retryButton
                     }

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct TranscriptionView: View {
     let recording: Recording
     var vocabularyWords: [String] = []
+    var transcriberType: TranscriberType = .speechTranscriber
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
@@ -50,8 +51,9 @@ struct TranscriptionView: View {
         }
         .task {
             viewModel.vocabularyWords = vocabularyWords
+            viewModel.transcriberType = transcriberType
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _, _ in
+                viewModel.transcribe = { _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -84,7 +84,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -96,7 +96,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptyResult_doesNotSave() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "" }
+        vm.transcribe = { _, _, _, _ in "" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -182,7 +182,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_triggersSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "要約テスト結果" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -197,7 +197,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationUnavailable_setsUnavailableState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
         vm.isSummarizationAvailable = { false }
         vm.startRecording()
         vm.stopRecording()
@@ -211,7 +211,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptySummary_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -226,7 +226,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -242,7 +242,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_transcribeThrows_doesNotTriggerSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         var summarizeCalled = false
-        vm.transcribe = { _, _, _ in
+        vm.transcribe = { _, _, _, _ in
             throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
         }
         vm.summarize = { _ in
@@ -264,7 +264,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_passesVocabularyToTranscribe() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         var receivedWords: [String] = []
-        vm.transcribe = { _, _, words in
+        vm.transcribe = { _, _, words, _ in
             receivedWords = words
             return "テスト"
         }

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -23,7 +23,7 @@ struct SummarizationTests {
     ) -> TranscriptionViewModel {
         let vm = TranscriptionViewModel()
         vm.checkAuthorization = { .authorized }
-        vm.transcribe = { _, _ in "テスト書き起こし結果" }
+        vm.transcribe = { _, _, _, _ in "テスト書き起こし結果" }
         vm.summarize = { _ in summarizeResult }
         vm.isSummarizationAvailable = { available }
         return vm
@@ -123,7 +123,7 @@ struct SummarizationTests {
 
     @Test func transcriptionFailure_doesNotTriggerSummarization() async {
         let vm = makeViewModel()
-        vm.transcribe = { _, _ in
+        vm.transcribe = { _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
         let recording = makeRecording()

--- a/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
+++ b/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+@testable import MindEcho
+
+@MainActor
+struct TranscriberPreferenceTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "TranscriberPreferenceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return defaults
+    }
+
+    @Test func defaultType_isSpeechTranscriber() {
+        let defaults = makeDefaults()
+        let pref = TranscriberPreference(defaults: defaults)
+        #expect(pref.type == .speechTranscriber)
+    }
+
+    @Test func setType_persistsToUserDefaults() {
+        let defaults = makeDefaults()
+        let pref = TranscriberPreference(defaults: defaults)
+
+        pref.type = .dictationTranscriber
+
+        #expect(defaults.string(forKey: "transcriberType") == "dictationTranscriber")
+    }
+
+    @Test func initFromPersistedValue_restoresType() {
+        let defaults = makeDefaults()
+        defaults.set("dictationTranscriber", forKey: "transcriberType")
+
+        let pref = TranscriberPreference(defaults: defaults)
+
+        #expect(pref.type == .dictationTranscriber)
+    }
+
+    @Test func invalidPersistedValue_defaultsToSpeechTranscriber() {
+        let defaults = makeDefaults()
+        defaults.set("invalidValue", forKey: "transcriberType")
+
+        let pref = TranscriberPreference(defaults: defaults)
+
+        #expect(pref.type == .speechTranscriber)
+    }
+
+    @Test func transcriberType_displayNames() {
+        #expect(TranscriberType.speechTranscriber.displayName == "SpeechTranscriber")
+        #expect(TranscriberType.dictationTranscriber.displayName == "DictationTranscriber")
+    }
+
+    @Test func transcriberType_allCases() {
+        #expect(TranscriberType.allCases.count == 2)
+    }
+}

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -120,6 +120,32 @@ struct TranscriptionViewModelTests {
         #expect(recording.transcription == nil)
     }
 
+    @Test func retryTranscription_clearsAndRetranscribes() async {
+        let vm = makeAuthorizedViewModel()
+        var callCount = 0
+        vm.transcribe = { _, _, _, _ in
+            callCount += 1
+            return "書き起こし結果\(callCount)"
+        }
+        vm.isSummarizationAvailable = { false }
+
+        let recording = makeRecording()
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.state == .success("書き起こし結果1"))
+        #expect(recording.transcription == "書き起こし結果1")
+
+        // Set a summary to verify it gets cleared
+        recording.summary = "テスト要約"
+
+        await vm.retryTranscription(recording: recording)
+
+        #expect(vm.state == .success("書き起こし結果2"))
+        #expect(recording.transcription == "書き起こし結果2")
+        #expect(recording.summary == nil)
+        #expect(callCount == 2)
+    }
+
     @Test func startTranscription_passesVocabularyToTranscribe() async {
         let vm = makeAuthorizedViewModel()
         var receivedWords: [String] = []

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -27,7 +27,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenSuccess() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _ in
+        vm.transcribe = { _, _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             return "テスト書き起こし結果"
         }
@@ -47,7 +47,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _ in "保存されるテキスト" }
+        vm.transcribe = { _, _, _, _ in "保存されるテキスト" }
 
         let recording = makeRecording()
         #expect(recording.transcription == nil)
@@ -61,7 +61,7 @@ struct TranscriptionViewModelTests {
     @Test func startTranscription_existingTranscription_showsImmediately() async {
         let vm = makeAuthorizedViewModel()
         var transcribeCalled = false
-        vm.transcribe = { _, _, _ in
+        vm.transcribe = { _, _, _, _ in
             transcribeCalled = true
             return "新しいテキスト"
         }
@@ -77,7 +77,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenFailure() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _ in
+        vm.transcribe = { _, _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
         }
@@ -101,7 +101,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_emptyResult_showsFailure() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _ in "" }
+        vm.transcribe = { _, _, _, _ in "" }
 
         let recording = makeRecording()
         await vm.startTranscription(recording: recording)
@@ -111,7 +111,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_failure_doesNotSaveTranscription() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _ in
+        vm.transcribe = { _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
 
@@ -123,7 +123,7 @@ struct TranscriptionViewModelTests {
     @Test func startTranscription_passesVocabularyToTranscribe() async {
         let vm = makeAuthorizedViewModel()
         var receivedWords: [String] = []
-        vm.transcribe = { _, _, words in
+        vm.transcribe = { _, _, words, _ in
             receivedWords = words
             return "テスト"
         }


### PR DESCRIPTION
## Summary
- SpeechTranscriber（高精度・生テキスト）と DictationTranscriber（句読点付き・カスタム語彙対応）を設定画面から切り替え可能にした
- `TranscriberType` enum と `TranscriberPreference`（UserDefaults ストア）を追加
- TranscriptionService / LiveTranscriptionService を両エンジン対応に拡張
- SettingsView を新設し、HomeView ツールバーの歯車アイコンから遷移可能に

## Test plan
- [ ] TranscriberPreferenceTests が全て通ること（デフォルト値、永続化、復元、不正値ハンドリング）
- [ ] 既存の TranscriptionViewModelTests / HomeViewModelTests / SummarizationTests が全て通ること
- [ ] 設定画面で SpeechTranscriber ↔ DictationTranscriber を切り替えられること
- [ ] 各エンジンで録音後の書き起こしが正常に動作すること
- [ ] アプリ再起動後も選択したエンジンが保持されること

https://claude.ai/code/session_01VriR5zWvZvqGrLwXs9tCLf