### PR TITLE
書き起こしテキストのPDFエクスポート・共有機能を追加

### DIFF
--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Foundation
 import MindEchoAudio
 import MindEchoCore
+import UIKit
 
 struct ExportServiceImpl: Exporting {
     func exportMergedAudio(entry: JournalEntry, to directory: URL) async throws -> URL {
@@ -33,6 +34,86 @@ struct ExportServiceImpl: Exporting {
         try? FileManager.default.removeItem(at: exportURL)
         try FileManager.default.copyItem(at: mergedURL, to: exportURL)
 
+        return exportURL
+    }
+
+    func exportTranscriptPDF(entry: JournalEntry, to directory: URL) throws -> URL {
+        try FilePathManager.ensureDirectoryExists(directory)
+
+        let dateHeader = DateHelper.displayString(for: entry.date)
+        let transcriptions = entry.sortedRecordings.compactMap(\.transcription)
+        let body = transcriptions.joined(separator: "\n\n")
+
+        let pageRect = CGRect(x: 0, y: 0, width: 595.2, height: 841.8) // A4
+        let margin: CGFloat = 50
+        let contentRect = pageRect.insetBy(dx: margin, dy: margin)
+
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 20),
+            .foregroundColor: UIColor.label,
+        ]
+        let bodyAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 14),
+            .foregroundColor: UIColor.label,
+        ]
+
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+        let data = renderer.pdfData { context in
+            // Draw title on first page
+            context.beginPage()
+            let titleString = NSAttributedString(string: dateHeader, attributes: titleAttributes)
+            let titleSize = titleString.boundingRect(
+                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin],
+                context: nil
+            )
+            titleString.draw(in: CGRect(
+                x: contentRect.origin.x,
+                y: contentRect.origin.y,
+                width: contentRect.width,
+                height: titleSize.height
+            ))
+
+            // Draw body text with automatic page breaks
+            let bodyTop = contentRect.origin.y + titleSize.height + 20
+            let bodyString = NSAttributedString(string: body, attributes: bodyAttributes)
+            let textStorage = NSTextStorage(attributedString: bodyString)
+            let layoutManager = NSLayoutManager()
+            textStorage.addLayoutManager(layoutManager)
+
+            var currentY = bodyTop
+            let textContainerWidth = contentRect.width
+            var glyphIndex = 0
+
+            while glyphIndex < layoutManager.numberOfGlyphs {
+                let availableHeight = pageRect.height - margin - currentY
+                let textContainer = NSTextContainer(
+                    size: CGSize(width: textContainerWidth, height: availableHeight)
+                )
+                textContainer.lineFragmentPadding = 0
+                layoutManager.addTextContainer(textContainer)
+
+                let glyphRange = layoutManager.glyphRange(for: textContainer)
+                if glyphRange.length == 0 { break }
+
+                layoutManager.drawBackground(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+                layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+
+                glyphIndex = NSMaxRange(glyphRange)
+                if glyphIndex < layoutManager.numberOfGlyphs {
+                    context.beginPage()
+                    currentY = margin
+                }
+            }
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let dateStr = formatter.string(from: entry.date)
+        let exportURL = directory.appendingPathComponent("\(dateStr)_transcript.pdf")
+
+        try data.write(to: exportURL)
         return exportURL
     }
 

--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -40,79 +40,11 @@ struct ExportServiceImpl: Exporting {
     func exportTranscriptPDF(entry: JournalEntry, to directory: URL) throws -> URL {
         try FilePathManager.ensureDirectoryExists(directory)
 
-        let dateHeader = DateHelper.displayString(for: entry.date)
-        let transcriptions = entry.sortedRecordings.compactMap(\.transcription)
-        let body = transcriptions.joined(separator: "\n\n")
+        let title = DateHelper.displayString(for: entry.date)
+        let body = entry.sortedRecordings.compactMap(\.transcription).joined(separator: "\n\n")
+        let data = PDFRenderer.render(title: title, body: body)
 
-        let pageRect = CGRect(x: 0, y: 0, width: 595.2, height: 841.8) // A4
-        let margin: CGFloat = 50
-        let contentRect = pageRect.insetBy(dx: margin, dy: margin)
-
-        let titleAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.boldSystemFont(ofSize: 20),
-            .foregroundColor: UIColor.label,
-        ]
-        let bodyAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 14),
-            .foregroundColor: UIColor.label,
-        ]
-
-        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
-        let data = renderer.pdfData { context in
-            // Draw title on first page
-            context.beginPage()
-            let titleString = NSAttributedString(string: dateHeader, attributes: titleAttributes)
-            let titleSize = titleString.boundingRect(
-                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
-                options: [.usesLineFragmentOrigin],
-                context: nil
-            )
-            titleString.draw(in: CGRect(
-                x: contentRect.origin.x,
-                y: contentRect.origin.y,
-                width: contentRect.width,
-                height: titleSize.height
-            ))
-
-            // Draw body text with automatic page breaks
-            let bodyTop = contentRect.origin.y + titleSize.height + 20
-            let bodyString = NSAttributedString(string: body, attributes: bodyAttributes)
-            let textStorage = NSTextStorage(attributedString: bodyString)
-            let layoutManager = NSLayoutManager()
-            textStorage.addLayoutManager(layoutManager)
-
-            var currentY = bodyTop
-            let textContainerWidth = contentRect.width
-            var glyphIndex = 0
-
-            while glyphIndex < layoutManager.numberOfGlyphs {
-                let availableHeight = pageRect.height - margin - currentY
-                let textContainer = NSTextContainer(
-                    size: CGSize(width: textContainerWidth, height: availableHeight)
-                )
-                textContainer.lineFragmentPadding = 0
-                layoutManager.addTextContainer(textContainer)
-
-                let glyphRange = layoutManager.glyphRange(for: textContainer)
-                if glyphRange.length == 0 { break }
-
-                layoutManager.drawBackground(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
-                layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
-
-                glyphIndex = NSMaxRange(glyphRange)
-                if glyphIndex < layoutManager.numberOfGlyphs {
-                    context.beginPage()
-                    currentY = margin
-                }
-            }
-        }
-
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyyMMdd"
-        let dateStr = formatter.string(from: entry.date)
-        let exportURL = directory.appendingPathComponent("\(dateStr)_transcript.pdf")
-
+        let exportURL = FilePathManager.exportPDFURL(for: entry.date)
         try data.write(to: exportURL)
         return exportURL
     }

--- a/MindEcho/MindEcho/Services/PDFRenderer.swift
+++ b/MindEcho/MindEcho/Services/PDFRenderer.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+enum PDFRenderer {
+    private static let pageRect = CGRect(x: 0, y: 0, width: 595.2, height: 841.8) // A4
+    private static let margin: CGFloat = 50
+
+    private static let titleAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.boldSystemFont(ofSize: 20),
+        .foregroundColor: UIColor.label,
+    ]
+    private static let bodyAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 14),
+        .foregroundColor: UIColor.label,
+    ]
+
+    /// Renders a simple PDF with a title and body text, returning the raw PDF data.
+    static func render(title: String, body: String) -> Data {
+        let contentRect = pageRect.insetBy(dx: margin, dy: margin)
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+
+        return renderer.pdfData { context in
+            context.beginPage()
+            let titleString = NSAttributedString(string: title, attributes: titleAttributes)
+            let titleSize = titleString.boundingRect(
+                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin],
+                context: nil
+            )
+            titleString.draw(in: CGRect(
+                x: contentRect.origin.x,
+                y: contentRect.origin.y,
+                width: contentRect.width,
+                height: titleSize.height
+            ))
+
+            let bodyTop = contentRect.origin.y + titleSize.height + 20
+            let bodyString = NSAttributedString(string: body, attributes: bodyAttributes)
+            let textStorage = NSTextStorage(attributedString: bodyString)
+            let layoutManager = NSLayoutManager()
+            textStorage.addLayoutManager(layoutManager)
+
+            var currentY = bodyTop
+            var glyphIndex = 0
+
+            while glyphIndex < layoutManager.numberOfGlyphs {
+                let availableHeight = pageRect.height - margin - currentY
+                let textContainer = NSTextContainer(
+                    size: CGSize(width: contentRect.width, height: availableHeight)
+                )
+                textContainer.lineFragmentPadding = 0
+                layoutManager.addTextContainer(textContainer)
+
+                let glyphRange = layoutManager.glyphRange(for: textContainer)
+                if glyphRange.length == 0 { break }
+
+                layoutManager.drawBackground(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+                layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+
+                glyphIndex = NSMaxRange(glyphRange)
+                if glyphIndex < layoutManager.numberOfGlyphs {
+                    context.beginPage()
+                    currentY = margin
+                }
+            }
+        }
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -306,6 +306,11 @@ class HomeViewModel {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    func exportTranscriptPDFForSharing(entry: JournalEntry) throws -> URL {
+        let exportDir = FilePathManager.exportsDirectory
+        return try exportService.exportTranscriptPDF(entry: entry, to: exportDir)
+    }
+
     // MARK: - Private
 
     private func getOrCreateEntry(for logicalDate: Date) -> JournalEntry {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -285,6 +285,13 @@ struct HomeView: View {
                 Label("テキストを共有", systemImage: "doc.text")
             }
             .accessibilityIdentifier("\(prefix).shareTranscriptButton\(suffix)")
+
+            Button {
+                exportAndSharePDF(entry: entry)
+            } label: {
+                Label("PDFで共有", systemImage: "doc.richtext")
+            }
+            .accessibilityIdentifier("\(prefix).sharePDFButton\(suffix)")
         } label: {
             Image(systemName: "square.and.arrow.up")
         }
@@ -297,6 +304,17 @@ struct HomeView: View {
         Task {
             do {
                 let url = try await viewModel.exportForSharing(entry: entry)
+                shareItems = [url]
+            } catch {
+                // Handle error silently for now
+            }
+        }
+    }
+
+    private func exportAndSharePDF(entry: JournalEntry) {
+        Task { @MainActor in
+            do {
+                let url = try viewModel.exportTranscriptPDFForSharing(entry: entry)
                 shareItems = [url]
             } catch {
                 // Handle error silently for now

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -1,12 +1,14 @@
 import MindEchoCore
 import Speech
 import SwiftUI
+import UIKit
 
 struct TranscriptionView: View {
     let recording: Recording
     var vocabularyWords: [String] = []
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
+    @State private var shareItems: [Any]?
 
     var body: some View {
         NavigationStack {
@@ -46,6 +48,24 @@ struct TranscriptionView: View {
                     }
                     .accessibilityIdentifier("transcription.closeButton")
                 }
+                if case .success = viewModel.state {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            sharePDF()
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                        .accessibilityIdentifier("transcription.shareButton")
+                    }
+                }
+            }
+            .sheet(isPresented: Binding(
+                get: { shareItems != nil },
+                set: { if !$0 { shareItems = nil } }
+            )) {
+                if let items = shareItems {
+                    ShareSheet(activityItems: items)
+                }
             }
         }
         .task {
@@ -66,6 +86,75 @@ struct TranscriptionView: View {
             }
             await viewModel.startTranscription(recording: recording)
         }
+    }
+
+    private func sharePDF() {
+        guard case .success(let text) = viewModel.state else { return }
+        let title = "書き起こし #\(recording.sequenceNumber)"
+        let pageRect = CGRect(x: 0, y: 0, width: 595.2, height: 841.8)
+        let margin: CGFloat = 50
+        let contentRect = pageRect.insetBy(dx: margin, dy: margin)
+
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.boldSystemFont(ofSize: 20),
+            .foregroundColor: UIColor.label,
+        ]
+        let bodyAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 14),
+            .foregroundColor: UIColor.label,
+        ]
+
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+        let data = renderer.pdfData { context in
+            context.beginPage()
+            let titleString = NSAttributedString(string: title, attributes: titleAttributes)
+            let titleSize = titleString.boundingRect(
+                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin],
+                context: nil
+            )
+            titleString.draw(in: CGRect(
+                x: contentRect.origin.x,
+                y: contentRect.origin.y,
+                width: contentRect.width,
+                height: titleSize.height
+            ))
+
+            let bodyTop = contentRect.origin.y + titleSize.height + 20
+            let bodyString = NSAttributedString(string: text, attributes: bodyAttributes)
+            let textStorage = NSTextStorage(attributedString: bodyString)
+            let layoutManager = NSLayoutManager()
+            textStorage.addLayoutManager(layoutManager)
+
+            var currentY = bodyTop
+            var glyphIndex = 0
+
+            while glyphIndex < layoutManager.numberOfGlyphs {
+                let availableHeight = pageRect.height - margin - currentY
+                let textContainer = NSTextContainer(
+                    size: CGSize(width: contentRect.width, height: availableHeight)
+                )
+                textContainer.lineFragmentPadding = 0
+                layoutManager.addTextContainer(textContainer)
+
+                let glyphRange = layoutManager.glyphRange(for: textContainer)
+                if glyphRange.length == 0 { break }
+
+                layoutManager.drawBackground(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+                layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
+
+                glyphIndex = NSMaxRange(glyphRange)
+                if glyphIndex < layoutManager.numberOfGlyphs {
+                    context.beginPage()
+                    currentY = margin
+                }
+            }
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transcription_\(recording.sequenceNumber).pdf")
+        try? data.write(to: tempURL)
+        shareItems = [tempURL]
     }
 
     @ViewBuilder

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -1,7 +1,6 @@
 import MindEchoCore
 import Speech
 import SwiftUI
-import UIKit
 
 struct TranscriptionView: View {
     let recording: Recording
@@ -91,70 +90,16 @@ struct TranscriptionView: View {
     private func sharePDF() {
         guard case .success(let text) = viewModel.state else { return }
         let title = "書き起こし #\(recording.sequenceNumber)"
-        let pageRect = CGRect(x: 0, y: 0, width: 595.2, height: 841.8)
-        let margin: CGFloat = 50
-        let contentRect = pageRect.insetBy(dx: margin, dy: margin)
-
-        let titleAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.boldSystemFont(ofSize: 20),
-            .foregroundColor: UIColor.label,
-        ]
-        let bodyAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 14),
-            .foregroundColor: UIColor.label,
-        ]
-
-        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
-        let data = renderer.pdfData { context in
-            context.beginPage()
-            let titleString = NSAttributedString(string: title, attributes: titleAttributes)
-            let titleSize = titleString.boundingRect(
-                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
-                options: [.usesLineFragmentOrigin],
-                context: nil
-            )
-            titleString.draw(in: CGRect(
-                x: contentRect.origin.x,
-                y: contentRect.origin.y,
-                width: contentRect.width,
-                height: titleSize.height
-            ))
-
-            let bodyTop = contentRect.origin.y + titleSize.height + 20
-            let bodyString = NSAttributedString(string: text, attributes: bodyAttributes)
-            let textStorage = NSTextStorage(attributedString: bodyString)
-            let layoutManager = NSLayoutManager()
-            textStorage.addLayoutManager(layoutManager)
-
-            var currentY = bodyTop
-            var glyphIndex = 0
-
-            while glyphIndex < layoutManager.numberOfGlyphs {
-                let availableHeight = pageRect.height - margin - currentY
-                let textContainer = NSTextContainer(
-                    size: CGSize(width: contentRect.width, height: availableHeight)
-                )
-                textContainer.lineFragmentPadding = 0
-                layoutManager.addTextContainer(textContainer)
-
-                let glyphRange = layoutManager.glyphRange(for: textContainer)
-                if glyphRange.length == 0 { break }
-
-                layoutManager.drawBackground(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
-                layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: CGPoint(x: contentRect.origin.x, y: currentY))
-
-                glyphIndex = NSMaxRange(glyphRange)
-                if glyphIndex < layoutManager.numberOfGlyphs {
-                    context.beginPage()
-                    currentY = margin
-                }
-            }
-        }
+        let data = PDFRenderer.render(title: title, body: text)
 
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("transcription_\(recording.sequenceNumber).pdf")
-        try? data.write(to: tempURL)
-        shareItems = [tempURL]
+        do {
+            try data.write(to: tempURL)
+            shareItems = [tempURL]
+        } catch {
+            // PDF write failed — do not present share sheet with invalid URL
+        }
     }
 
     @ViewBuilder

--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -70,6 +70,26 @@ final class EntryDetailUITests: XCTestCase {
     }
 
     @MainActor
+    func testSharePDFButton_presentsActivitySheet() throws {
+        app.launch()
+
+        let shareBtn = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.shareButton'")
+        ).firstMatch
+        XCTAssertTrue(shareBtn.waitForExistence(timeout: 5))
+        shareBtn.tap()
+
+        // Share type menu should appear — tap "PDFで共有"
+        let pdfBtn = app.buttons["PDFで共有"]
+        XCTAssertTrue(pdfBtn.waitForExistence(timeout: 5))
+        pdfBtn.tap()
+
+        // UIActivityViewController should appear after PDF export
+        let activityList = app.otherElements["ActivityListView"]
+        XCTAssertTrue(activityList.waitForExistence(timeout: 15))
+    }
+
+    @MainActor
     func testMenuDelete_removesRecording() throws {
         app.launch()
 

--- a/Packages/MindEchoCore/Sources/MindEchoCore/Exporting.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/Exporting.swift
@@ -3,4 +3,5 @@ import Foundation
 public protocol Exporting {
     func exportMergedAudio(entry: JournalEntry, to directory: URL) async throws -> URL
     func exportCombinedTranscript(entry: JournalEntry, to directory: URL) throws -> URL
+    func exportTranscriptPDF(entry: JournalEntry, to directory: URL) throws -> URL
 }

--- a/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
@@ -52,6 +52,15 @@ public enum FilePathManager {
         return exportsDirectory.appendingPathComponent(fileName)
     }
 
+    /// Returns the export PDF URL for a given logical date
+    public static func exportPDFURL(for logicalDate: Date) -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let fileName = formatter.string(from: logicalDate) + "_transcript.pdf"
+        return exportsDirectory.appendingPathComponent(fileName)
+    }
+
     /// Ensures a directory exists, creating it if necessary
     public static func ensureDirectoryExists(_ url: URL) throws {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -1,6 +1,6 @@
 # UIテスト設計
 
-メインシナリオを選定し XCTest で UIテストを記述する（6カテゴリ・18テストケース）。
+メインシナリオを選定し XCTest で UIテストを記述する（6カテゴリ・19テストケース）。
 
 ## テストデータセットアップ（Launch Arguments）
 
@@ -56,6 +56,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `home.shareButton` — 共有メニューボタン（今日のセクションヘッダー内、録音が存在する場合のみ表示）
 - `home.shareAudioButton` — 共有メニュー内の「音声を共有」ボタン
 - `home.shareTranscriptButton` — 共有メニュー内の「テキストを共有」ボタン
+- `home.sharePDFButton` — 共有メニュー内の「PDFで共有」ボタン
 
 **過去のセクション**
 
@@ -66,6 +67,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `past.shareButton.{date}` — 過去のセクションヘッダー内の共有メニューボタン（録音が存在する場合のみ表示）
 - `past.shareAudioButton.{date}` — 過去の共有メニュー内の「音声を共有」ボタン
 - `past.shareTranscriptButton.{date}` — 過去の共有メニュー内の「テキストを共有」ボタン
+- `past.sharePDFButton.{date}` — 過去の共有メニュー内の「PDFで共有」ボタン
 - `past.recordingRow.{date}.{n}` — 過去の録音行。タップで TranscriptionView へ遷移
 - `past.playButton.{date}.{n}` — 過去の録音の再生ボタン（セル右端、非再生時に表示）
 - `past.pauseButton.{date}.{n}` — 過去の録音の一時停止ボタン（セル右端、再生中に表示）
@@ -115,6 +117,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryLoading` — 要約生成中のプログレス表示
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
+- `transcription.shareButton` — 書き起こし結果の共有ボタン（PDF形式、ナビゲーションバー右端、書き起こし成功時のみ表示）
 
 ## テストケース（6カテゴリ・18テスト）
 
@@ -170,7 +173,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testSeededHistory_displaysEntries` | シードデータが統合リストに表示され、録音なし日付にも `past.addButton.{date}` が表示される |
 | `testEntryRow_showsDatePreviewAndRecordingInfo` | セルに録音情報が表示される |
 
-### 4. EntryDetailUITests（5テスト）
+### 4. EntryDetailUITests（6テスト）
 
 統合ビュー上で今日の録音に対するテストを実施（旧 EntryDetailView のテストを HomeView に移行）。
 
@@ -179,6 +182,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 | `testHomeView_showsDateAndRecordingsList` | 日付と録音リストの表示 |
 | `testShareButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「音声を共有」選択で Activity Sheet 表示 |
 | `testShareTranscriptButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「テキストを共有」選択で Activity Sheet 表示 |
+| `testSharePDFButton_presentsActivitySheet` | セクションヘッダーの共有ボタンタップで共有タイプ選択メニュー表示 → 「PDFで共有」選択で Activity Sheet 表示 |
 | `testMenuDelete_removesRecording` | メニューボタン（…）タップ → 削除メニューアイテムタップで録音が削除される |
 | `testPlayButton_togglesPlaybackState` | 再生ボタンタップで一時停止ボタンに切り替わり、一時停止タップで再生ボタンに戻る |
 


### PR DESCRIPTION
## Summary
- 書き起こしテキストをシンプルなA4 PDFとして生成し、共有シートで共有できる機能を追加
- HomeView の共有メニューに「PDFで共有」オプションを追加（日単位の全書き起こしを1つのPDFに統合）
- TranscriptionView に共有ボタンを追加（個別録音の書き起こしをPDFとして共有）
- PDF生成ロジックは `PDFRenderer` ユーティリティに共通化し、重複を排除

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `PDFRenderer.swift` | 新規: A4 PDF生成の共通ユーティリティ（タイトル+本文、自動ページ分割） |
| `Exporting.swift` | `exportTranscriptPDF` メソッドをプロトコルに追加 |
| `FilePathManager.swift` | `exportPDFURL(for:)` ヘルパーを追加 |
| `ExportService.swift` | `PDFRenderer` を使用したPDFエクスポート実装 |
| `HomeViewModel.swift` | `exportTranscriptPDFForSharing` メソッドを追加 |
| `HomeView.swift` | 共有メニューに「PDFで共有」ボタンを追加 |
| `TranscriptionView.swift` | ナビバーに共有ボタン + PDFRenderer 経由のPDF共有 |
| `EntryDetailUITests.swift` | PDF共有のUIテストを追加 |
| `ui-test-design.md` | アクセシビリティID・テストケースを追記（19テスト） |

## Test plan
- [ ] HomeView の共有メニューから「PDFで共有」をタップし、共有シートが表示されることを確認
- [ ] TranscriptionView の共有ボタンをタップし、個別録音のPDFが共有されることを確認
- [ ] 生成されたPDFが正しいタイトルと書き起こし内容を含むことを確認
- [ ] 長文の書き起こしで自動ページ分割が正しく動作することを確認
- [ ] `testSharePDFButton_presentsActivitySheet` UIテストがパスすることを確認

https://claude.ai/code/session_013uL4jqfrYzphtt9QKFLzGE