### PR TITLE
書き起こしエンジン設定を事後の書き起こしのみに限定

### DIFF
--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -349,7 +349,7 @@ class HomeViewModel {
             liveTranscriber.feedAudioBuffer(buffer, format: format)
         }
 
-        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords, transcriberType: transcriberType)
+        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords)
         liveTranscriptionTask = Task { @MainActor [weak self] in
             do {
                 for try await text in stream {

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
                 } header: {
                     Text("書き起こしエンジン")
                 } footer: {
-                    Text("SpeechTranscriber は高精度な生テキスト出力に対応しています。DictationTranscriber は句読点付きの出力に対応しています。どちらもカスタム語彙を利用できます。")
+                    Text("録音完了後の書き起こしに使用するエンジンを選択します。リアルタイム書き起こしには常に SpeechTranscriber が使用されます。")
                 }
             }
             .navigationTitle("設定")


### PR DESCRIPTION
## Summary
- リアルタイム書き起こしでは設定に関係なく常に SpeechTranscriber を使用するように変更
- 事後の書き起こし（TranscriptionView / HomeViewModel.startTranscription）のみ設定値に従う
- 設定画面のフッターテキストを更新し、適用範囲を明示

## Test plan
- [ ] 設定で DictationTranscriber を選択した状態で録音し、リアルタイム書き起こしが SpeechTranscriber で動作することを確認
- [ ] 録音完了後の書き起こし（TranscriptionView）で DictationTranscriber が使用されることを確認
- [ ] 設定画面のフッターテキストが正しく表示されることを確認

https://claude.ai/code/session_012irf8Czzwx2mgqG5sw9bQV