### PR TITLE
feat: Whisper API による文字起こし機能を追加 (#92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `VocabularyView` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, WhisperAPIService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `OpenAIAPIKeyStore`, `WhisperAPIService`, `VocabularyView` 等 |
 
 ### Design Principles
 
@@ -132,8 +132,10 @@ xcodebuild test \
 
 書き起こしエンジンの設定は、リアルタイム書き起こしと事後書き起こしで独立しています。
 
-- `TranscriberPreference.liveType` — 録音中のリアルタイム書き起こしに使用するエンジン
-- `TranscriberPreference.postRecordingType` — 録音完了後の書き起こしに使用するエンジン
+- `TranscriberPreference.liveType` — 録音中のリアルタイム書き起こしに使用するエンジン（`speechTranscriber`, `dictationTranscriber`）
+- `TranscriberPreference.postRecordingType` — 録音完了後の書き起こしに使用するエンジン（`speechTranscriber`, `dictationTranscriber`, `whisperAPI`）
+- `OpenAIAPIKeyStore` — OpenAI API キーの管理（UserDefaults に保存）
+- `.whisperAPI` はポスト書き起こし専用。リアルタイム書き起こしのリストには表示しない
 
 
 ### Data Model Relationships

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -24,7 +24,7 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
 
     func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber) -> AsyncThrowingStream<String, Error> {
         switch transcriberType {
-        case .speechTranscriber:
+        case .speechTranscriber, .whisperAPI:
             startWithSpeechTranscriber(locale: locale, contextualStrings: contextualStrings)
         case .dictationTranscriber:
             startWithDictationTranscriber(locale: locale, contextualStrings: contextualStrings)

--- a/MindEcho/MindEcho/Services/TranscriberPreference.swift
+++ b/MindEcho/MindEcho/Services/TranscriberPreference.swift
@@ -4,6 +4,7 @@ import Observation
 enum TranscriberType: String, CaseIterable, Sendable {
     case speechTranscriber
     case dictationTranscriber
+    case whisperAPI
 
     var displayName: String {
         switch self {
@@ -11,6 +12,8 @@ enum TranscriberType: String, CaseIterable, Sendable {
             "SpeechTranscriber"
         case .dictationTranscriber:
             "DictationTranscriber"
+        case .whisperAPI:
+            "Whisper API"
         }
     }
 
@@ -20,7 +23,37 @@ enum TranscriberType: String, CaseIterable, Sendable {
             "高精度・生テキスト出力"
         case .dictationTranscriber:
             "句読点付き出力"
+        case .whisperAPI:
+            "OpenAI Whisper API（ネットワーク必須・音声データが外部送信されます）"
         }
+    }
+
+    /// リアルタイム書き起こしで使用可能なケース
+    static var liveCases: [TranscriberType] {
+        [.speechTranscriber, .dictationTranscriber]
+    }
+
+    /// 事後書き起こしで使用可能なケース
+    static var postRecordingCases: [TranscriberType] {
+        allCases
+    }
+}
+
+@Observable
+final class OpenAIAPIKeyStore {
+    private static let apiKeyKey = "openAIAPIKey"
+
+    private let defaults: UserDefaults
+    private let keyName: String
+
+    var apiKey: String {
+        didSet { defaults.set(apiKey, forKey: keyName) }
+    }
+
+    init(defaults: UserDefaults = .standard, key: String = apiKeyKey) {
+        self.defaults = defaults
+        self.keyName = key
+        self.apiKey = defaults.string(forKey: key) ?? ""
     }
 }
 

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -7,13 +7,16 @@ struct TranscriptionService {
         audioFileURL: URL,
         locale: Locale,
         contextualStrings: [String] = [],
-        transcriberType: TranscriberType = .speechTranscriber
+        transcriberType: TranscriberType = .speechTranscriber,
+        openAIAPIKey: String = ""
     ) async throws -> String {
         switch transcriberType {
         case .speechTranscriber:
             try await transcribeWithSpeech(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
         case .dictationTranscriber:
             try await transcribeWithDictation(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
+        case .whisperAPI:
+            try await WhisperAPIService().transcribe(audioFileURL: audioFileURL, apiKey: openAIAPIKey)
         }
     }
 

--- a/MindEcho/MindEcho/Services/WhisperAPIService.swift
+++ b/MindEcho/MindEcho/Services/WhisperAPIService.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct WhisperAPIService: Sendable {
+    enum WhisperError: LocalizedError {
+        case apiKeyMissing
+        case fileTooLarge(Int)
+        case apiError(String)
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .apiKeyMissing:
+                "OpenAI API キーが設定されていません。設定画面から API キーを入力してください。"
+            case .fileTooLarge(let sizeMB):
+                "音声ファイルが上限（25MB）を超えています（\(sizeMB)MB）。"
+            case .apiError(let message):
+                "Whisper API エラー: \(message)"
+            case .invalidResponse:
+                "Whisper API から不正なレスポンスが返されました。"
+            }
+        }
+    }
+
+    private static let maxFileSize = 25 * 1024 * 1024 // 25MB
+    private static let endpoint = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
+
+    func transcribe(audioFileURL: URL, apiKey: String) async throws -> String {
+        guard !apiKey.isEmpty else {
+            throw WhisperError.apiKeyMissing
+        }
+
+        let fileData = try Data(contentsOf: audioFileURL)
+        if fileData.count > Self.maxFileSize {
+            throw WhisperError.fileTooLarge(fileData.count / (1024 * 1024))
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        let fileName = audioFileURL.lastPathComponent
+
+        func appendField(name: String, value: String) {
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+            body.append("\(value)\r\n".data(using: .utf8)!)
+        }
+
+        // file field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/m4a\r\n\r\n".data(using: .utf8)!)
+        body.append(fileData)
+        body.append("\r\n".data(using: .utf8)!)
+
+        appendField(name: "model", value: "gpt-4o-transcribe")
+        appendField(name: "language", value: "ja")
+        appendField(name: "response_format", value: "text")
+
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw WhisperError.invalidResponse
+        }
+
+        if httpResponse.statusCode != 200 {
+            if let errorBody = String(data: data, encoding: .utf8), !errorBody.isEmpty {
+                throw WhisperError.apiError(errorBody)
+            }
+            throw WhisperError.apiError("HTTP \(httpResponse.statusCode)")
+        }
+
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw WhisperError.invalidResponse
+        }
+
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -37,10 +37,11 @@ class HomeViewModel {
     var vocabularyWords: [String] = []
     var liveTranscriberType: TranscriberType = .speechTranscriber
     var postRecordingTranscriberType: TranscriberType = .speechTranscriber
+    var openAIAPIKey: String = ""
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String], TranscriberType) async throws -> String = { url, locale, contextualStrings, transcriberType in
-        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType)
+    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
+        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
     var summarize: (String) async throws -> String = SummarizationService().summarize
@@ -179,7 +180,7 @@ class HomeViewModel {
         transcriptionState = .loading
         summaryState = .idle
         do {
-            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords, postRecordingTranscriberType)
+            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords, postRecordingTranscriberType, openAIAPIKey)
             if text.isEmpty {
                 transcriptionState = .failure("書き起こし結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -24,9 +24,12 @@ final class TranscriptionViewModel {
     private(set) var summaryState: SummaryState = .idle
     var vocabularyWords: [String] = []
     var transcriberType: TranscriberType = .speechTranscriber
+    var openAIAPIKey: String = ""
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String], TranscriberType) async throws -> String = TranscriptionService().transcribe
+    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
+        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
+    }
     @ObservationIgnored
     var checkAuthorization: () -> SFSpeechRecognizerAuthorizationStatus = {
         SFSpeechRecognizer.authorizationStatus()
@@ -77,7 +80,7 @@ final class TranscriptionViewModel {
             .appendingPathComponent(recording.audioFileName)
 
         do {
-            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType)
+            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType, openAIAPIKey)
             if text.isEmpty {
                 state = .failure("書き起こし結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -10,6 +10,7 @@ struct HomeView: View {
     @State private var shareItems: [Any]?
     @State private var vocabularyStore = VocabularyStore()
     @State private var transcriberPreference = TranscriberPreference()
+    @State private var openAIAPIKeyStore = OpenAIAPIKeyStore()
     @State private var showVocabulary = false
     @State private var showSettings = false
 
@@ -85,6 +86,7 @@ struct HomeView: View {
                 viewModel.vocabularyWords = vocabularyStore.words
                 viewModel.liveTranscriberType = transcriberPreference.liveType
                 viewModel.postRecordingTranscriberType = transcriberPreference.postRecordingType
+                viewModel.openAIAPIKey = openAIAPIKeyStore.apiKey
                 viewModel.fetchAllEntries()
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
@@ -96,11 +98,14 @@ struct HomeView: View {
             .onChange(of: transcriberPreference.postRecordingType) { _, newType in
                 viewModel.postRecordingTranscriberType = newType
             }
+            .onChange(of: openAIAPIKeyStore.apiKey) { _, newKey in
+                viewModel.openAIAPIKey = newKey
+            }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
             }
             .sheet(isPresented: $showSettings) {
-                SettingsView(transcriberPreference: transcriberPreference)
+                SettingsView(transcriberPreference: transcriberPreference, openAIAPIKeyStore: openAIAPIKeyStore)
             }
             .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
                 if viewModel.isRecording {
@@ -113,7 +118,7 @@ struct HomeView: View {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType)
+                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
         }

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -138,7 +138,7 @@ struct RecordingModalView: View {
         }
         .onAppear {
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _, _, _ in
+                viewModel.transcribe = { _, _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 
 struct SettingsView: View {
     @Bindable var transcriberPreference: TranscriberPreference
+    @Bindable var openAIAPIKeyStore: OpenAIAPIKeyStore
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
             List {
                 Section {
-                    ForEach(TranscriberType.allCases, id: \.self) { type in
+                    ForEach(TranscriberType.liveCases, id: \.self) { type in
                         Button {
                             transcriberPreference.liveType = type
                         } label: {
@@ -36,7 +37,7 @@ struct SettingsView: View {
                 }
 
                 Section {
-                    ForEach(TranscriberType.allCases, id: \.self) { type in
+                    ForEach(TranscriberType.postRecordingCases, id: \.self) { type in
                         Button {
                             transcriberPreference.postRecordingType = type
                         } label: {
@@ -60,7 +61,19 @@ struct SettingsView: View {
                 } header: {
                     Text("事後書き起こしエンジン")
                 } footer: {
-                    Text("録音完了後の書き起こしに使用するエンジンです。SpeechTranscriber は高精度な生テキスト出力に対応しています。DictationTranscriber は句読点付きの出力に対応しています。どちらもカスタム語彙を利用できます。")
+                    Text("録音完了後の書き起こしに使用するエンジンです。Whisper API はネットワーク接続が必要で、音声データが OpenAI サーバーに送信されます。")
+                }
+
+                Section {
+                    SecureField("sk-...", text: $openAIAPIKeyStore.apiKey)
+                        .textContentType(.password)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .accessibilityIdentifier("settings.openAIAPIKey")
+                } header: {
+                    Text("OpenAI API キー")
+                } footer: {
+                    Text("Whisper API を使用するために必要です。API キーは端末内に保存されます。")
                 }
             }
             .navigationTitle("設定")

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -6,6 +6,7 @@ struct TranscriptionView: View {
     let recording: Recording
     var vocabularyWords: [String] = []
     var transcriberType: TranscriberType = .speechTranscriber
+    var openAIAPIKey: String = ""
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
@@ -61,8 +62,9 @@ struct TranscriptionView: View {
         .task {
             viewModel.vocabularyWords = vocabularyWords
             viewModel.transcriberType = transcriberType
+            viewModel.openAIAPIKey = openAIAPIKey
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
-                viewModel.transcribe = { _, _, _, _ in
+                viewModel.transcribe = { _, _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
                     return "これはモックの書き起こし結果です。テスト用のテキストデータ。"
                 }

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -84,7 +84,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -96,7 +96,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptyResult_doesNotSave() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "" }
+        vm.transcribe = { _, _, _, _, _ in "" }
         vm.startRecording()
         vm.stopRecording()
 
@@ -182,7 +182,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_triggersSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "要約テスト結果" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -197,7 +197,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationUnavailable_setsUnavailableState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
         vm.isSummarizationAvailable = { false }
         vm.startRecording()
         vm.stopRecording()
@@ -211,7 +211,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_emptySummary_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in "" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -226,7 +226,7 @@ struct HomeViewModelTests {
 
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
-        vm.transcribe = { _, _, _, _ in "書き起こしテスト結果" }
+        vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
         vm.summarize = { _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
@@ -242,7 +242,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_transcribeThrows_doesNotTriggerSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         var summarizeCalled = false
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
         }
         vm.summarize = { _ in
@@ -264,7 +264,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_passesVocabularyToTranscribe() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         var receivedWords: [String] = []
-        vm.transcribe = { _, _, words, _ in
+        vm.transcribe = { _, _, words, _, _ in
             receivedWords = words
             return "テスト"
         }

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -23,7 +23,7 @@ struct SummarizationTests {
     ) -> TranscriptionViewModel {
         let vm = TranscriptionViewModel()
         vm.checkAuthorization = { .authorized }
-        vm.transcribe = { _, _, _, _ in "テスト書き起こし結果" }
+        vm.transcribe = { _, _, _, _, _ in "テスト書き起こし結果" }
         vm.summarize = { _ in summarizeResult }
         vm.isSummarizationAvailable = { available }
         return vm
@@ -123,7 +123,7 @@ struct SummarizationTests {
 
     @Test func transcriptionFailure_doesNotTriggerSummarization() async {
         let vm = makeViewModel()
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
         let recording = makeRecording()

--- a/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
+++ b/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
@@ -76,9 +76,49 @@ struct TranscriberPreferenceTests {
     @Test func transcriberType_displayNames() {
         #expect(TranscriberType.speechTranscriber.displayName == "SpeechTranscriber")
         #expect(TranscriberType.dictationTranscriber.displayName == "DictationTranscriber")
+        #expect(TranscriberType.whisperAPI.displayName == "Whisper API")
     }
 
     @Test func transcriberType_allCases() {
-        #expect(TranscriberType.allCases.count == 2)
+        #expect(TranscriberType.allCases.count == 3)
+    }
+
+    @Test func transcriberType_liveCases_excludesWhisperAPI() {
+        #expect(TranscriberType.liveCases.count == 2)
+        #expect(!TranscriberType.liveCases.contains(.whisperAPI))
+    }
+
+    @Test func transcriberType_postRecordingCases_includesWhisperAPI() {
+        #expect(TranscriberType.postRecordingCases.count == 3)
+        #expect(TranscriberType.postRecordingCases.contains(.whisperAPI))
+    }
+
+    @Test func setPostRecordingType_whisperAPI_persistsToUserDefaults() {
+        let defaults = makeDefaults()
+        let pref = TranscriberPreference(defaults: defaults)
+
+        pref.postRecordingType = .whisperAPI
+
+        #expect(defaults.string(forKey: "postRecordingTranscriberType") == "whisperAPI")
+    }
+
+    @Test func openAIAPIKeyStore_defaultIsEmpty() {
+        let defaults = makeDefaults()
+        let store = OpenAIAPIKeyStore(defaults: defaults)
+        #expect(store.apiKey == "")
+    }
+
+    @Test func openAIAPIKeyStore_persistsKey() {
+        let defaults = makeDefaults()
+        let store = OpenAIAPIKeyStore(defaults: defaults, key: "testOpenAIAPIKey")
+        store.apiKey = "sk-test123"
+        #expect(defaults.string(forKey: "testOpenAIAPIKey") == "sk-test123")
+    }
+
+    @Test func openAIAPIKeyStore_restoresPersistedKey() {
+        let defaults = makeDefaults()
+        defaults.set("sk-persisted", forKey: "testOpenAIAPIKey")
+        let store = OpenAIAPIKeyStore(defaults: defaults, key: "testOpenAIAPIKey")
+        #expect(store.apiKey == "sk-persisted")
     }
 }

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -27,7 +27,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenSuccess() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             return "テスト書き起こし結果"
         }
@@ -47,7 +47,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_savesTranscriptionToRecording() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _, _ in "保存されるテキスト" }
+        vm.transcribe = { _, _, _, _, _ in "保存されるテキスト" }
 
         let recording = makeRecording()
         #expect(recording.transcription == nil)
@@ -61,7 +61,7 @@ struct TranscriptionViewModelTests {
     @Test func startTranscription_existingTranscription_showsImmediately() async {
         let vm = makeAuthorizedViewModel()
         var transcribeCalled = false
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             transcribeCalled = true
             return "新しいテキスト"
         }
@@ -77,7 +77,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_showsLoadingThenFailure() async throws {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             try await Task.sleep(for: .milliseconds(100))
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
         }
@@ -101,7 +101,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_emptyResult_showsFailure() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _, _ in "" }
+        vm.transcribe = { _, _, _, _, _ in "" }
 
         let recording = makeRecording()
         await vm.startTranscription(recording: recording)
@@ -111,7 +111,7 @@ struct TranscriptionViewModelTests {
 
     @Test func startTranscription_failure_doesNotSaveTranscription() async {
         let vm = makeAuthorizedViewModel()
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
 
@@ -123,7 +123,7 @@ struct TranscriptionViewModelTests {
     @Test func retryTranscription_clearsAndRetranscribes() async {
         let vm = makeAuthorizedViewModel()
         var callCount = 0
-        vm.transcribe = { _, _, _, _ in
+        vm.transcribe = { _, _, _, _, _ in
             callCount += 1
             return "書き起こし結果\(callCount)"
         }
@@ -149,7 +149,7 @@ struct TranscriptionViewModelTests {
     @Test func startTranscription_passesVocabularyToTranscribe() async {
         let vm = makeAuthorizedViewModel()
         var receivedWords: [String] = []
-        vm.transcribe = { _, _, words, _ in
+        vm.transcribe = { _, _, words, _, _ in
             receivedWords = words
             return "テスト"
         }

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -89,7 +89,8 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 ### SettingsView
 
 - `settings.liveTranscriber.{type}` — リアルタイム書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber）
-- `settings.postRecordingTranscriber.{type}` — 事後書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber）
+- `settings.postRecordingTranscriber.{type}` — 事後書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber | whisperAPI）
+- `settings.openAIAPIKey` — OpenAI API キー入力フィールド（SecureField）
 - `settings.closeButton` — シートを閉じるボタン（×アイコン）
 
 ### RecordingModalView


### PR DESCRIPTION
- TranscriberType に .whisperAPI ケースを追加（ポスト書き起こし専用）
- WhisperAPIService を新規作成（OpenAI /v1/audio/transcriptions エンドポイント）
- TranscriptionService に Whisper API 分岐を追加
- SettingsView に OpenAI API キー入力欄を追加、リアルタイム/事後書き起こしのエンジンリスト表示を分離
- OpenAIAPIKeyStore を追加（UserDefaults に保存）
- テスト追加・更新（TranscriberPreferenceTests, 既存テストの closure signature 更新）
- CLAUDE.md, docs/ui-test-design.md を更新

## 概要

<!-- このPRで何を変更したか簡潔に記述してください -->

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] ビルド・CI設定の変更
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

## 影響範囲

<!-- この変更が影響するファイル・画面・機能を記述してください -->

- 対象画面:
- 対象機能:

## スクリーンショット / 動画

<!-- UI変更がある場合、変更前後のスクリーンショットや動画を添付してください -->

| 変更前 | 変更後 |
|--------|--------|
|        |        |

## テスト

- [ ] ユニットテストを追加・更新した
- [ ] UIテストを追加・更新した
- [ ] シミュレータで動作確認した
- [ ] 実機で動作確認した

## チェックリスト

- [ ] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [ ] 不要なデバッグコード・print文を削除した
- [ ] 既存の機能にデグレがないことを確認した

## 関連Issue

<!-- 関連するIssue番号があればリンクしてください (例: #123) -->

## レビュアーへの補足

<!-- レビュー時に特に見てほしいポイントや注意点があれば記述してください -->
