### PR TITLE
feat: Whisper API 文字起こし時にカスタム辞書を利用する

### DIFF
--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -16,7 +16,7 @@ struct TranscriptionService {
         case .dictationTranscriber:
             try await transcribeWithDictation(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
         case .whisperAPI:
-            try await WhisperAPIService().transcribe(audioFileURL: audioFileURL, apiKey: openAIAPIKey)
+            try await WhisperAPIService().transcribe(audioFileURL: audioFileURL, apiKey: openAIAPIKey, contextualStrings: contextualStrings)
         }
     }
 

--- a/MindEcho/MindEcho/Services/WhisperAPIService.swift
+++ b/MindEcho/MindEcho/Services/WhisperAPIService.swift
@@ -24,7 +24,7 @@ struct WhisperAPIService: Sendable {
     private static let maxFileSize = 25 * 1024 * 1024 // 25MB
     private static let endpoint = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
 
-    func transcribe(audioFileURL: URL, apiKey: String) async throws -> String {
+    func transcribe(audioFileURL: URL, apiKey: String, contextualStrings: [String] = []) async throws -> String {
         guard !apiKey.isEmpty else {
             throw WhisperError.apiKeyMissing
         }
@@ -59,6 +59,10 @@ struct WhisperAPIService: Sendable {
         appendField(name: "model", value: "gpt-4o-transcribe")
         appendField(name: "language", value: "ja")
         appendField(name: "response_format", value: "text")
+
+        if !contextualStrings.isEmpty {
+            appendField(name: "prompt", value: contextualStrings.joined(separator: ", "))
+        }
 
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
         request.httpBody = body


### PR DESCRIPTION
## 概要

Whisper API による文字起こし時に、ユーザーが登録したカスタム辞書（VocabularyStore の単語リスト）が利用されるようにする。

## 変更の種類

- [x] バグ修正

## 変更内容

- `WhisperAPIService.transcribe()` に `contextualStrings: [String] = []` パラメータを追加
- `contextualStrings` が空でなければカンマ区切りで結合し、multipart の `prompt` フィールドとして送信
- `TranscriptionService` の `.whisperAPI` ケースで `contextualStrings` を `WhisperAPIService` に渡すように修正

## 影響範囲

- 対象画面: なし（内部サービス層の変更のみ）
- 対象機能: Whisper API による文字起こし

## スクリーンショット / 動画

なし（UI変更なし）

## チェックリスト

- [x] コードがビルドできることを確認した
- [x] 不要なデバッグコード・print文を削除した

## 関連Issue

Closes #97

## レビュアーへの補足

OpenAI Whisper API の `prompt` パラメータに VocabularyStore の単語リストをカンマ区切りで渡すことで、カスタム用語の認識精度を向上させます。単語リストが空の場合は `prompt` フィールド自体を送信しません。

Generated with [Claude Code](https://claude.ai/code)
