### PR TITLE
feat: 要約プロンプトを設定画面でカスタマイズ可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, WhisperAPIService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `OpenAIAPIKeyStore`, `WhisperAPIService`, `VocabularyView` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, SummaryPromptStore, TranscriberPreference, WhisperAPIService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `SummaryPromptStore`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `OpenAIAPIKeyStore`, `WhisperAPIService`, `VocabularyView` 等 |
 
 ### Design Principles
 

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -2,10 +2,10 @@ import Foundation
 import FoundationModels
 
 struct SummarizationService {
-    func summarize(text: String) async throws -> String {
+    func summarize(text: String, prompt: String = SummaryPromptStore.defaultPrompt) async throws -> String {
         let session = LanguageModelSession()
-        let prompt = "以下の書き起こしテキストを簡潔に要約してください。要約のみを出力し、余計な前置きは不要です。\n\n\(text)"
-        let response = try await session.respond(to: prompt)
+        let fullPrompt = "\(prompt)\n\n\(text)"
+        let response = try await session.respond(to: fullPrompt)
         return String(response.content).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/MindEcho/MindEcho/Services/SummaryPromptStore.swift
+++ b/MindEcho/MindEcho/Services/SummaryPromptStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Observation
+
+@Observable
+final class SummaryPromptStore {
+    static let defaultPrompt = "以下の書き起こしテキストを簡潔に要約してください。要約のみを出力し、余計な前置きは不要です。"
+
+    private static let promptKey = "summaryPrompt"
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    var prompt: String {
+        didSet { defaults.set(prompt, forKey: key) }
+    }
+
+    init(defaults: UserDefaults = .standard, key: String = promptKey) {
+        self.defaults = defaults
+        self.key = key
+        self.prompt = defaults.string(forKey: key) ?? Self.defaultPrompt
+    }
+
+    func resetToDefault() {
+        prompt = Self.defaultPrompt
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -38,13 +38,14 @@ class HomeViewModel {
     var liveTranscriberType: TranscriberType = .speechTranscriber
     var postRecordingTranscriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
+    var summaryPrompt: String = SummaryPromptStore.defaultPrompt
 
     @ObservationIgnored
     var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
         try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
-    var summarize: (String) async throws -> String = SummarizationService().summarize
+    var summarize: (String, String) async throws -> String = SummarizationService().summarize
     @ObservationIgnored
     var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
 
@@ -213,7 +214,7 @@ class HomeViewModel {
         }
         summaryState = .loading
         do {
-            let summary = try await summarize(text)
+            let summary = try await summarize(text, summaryPrompt)
             if summary.isEmpty {
                 summaryState = .failure("要約結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -25,6 +25,7 @@ final class TranscriptionViewModel {
     var vocabularyWords: [String] = []
     var transcriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
+    var summaryPrompt: String = SummaryPromptStore.defaultPrompt
 
     @ObservationIgnored
     var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
@@ -39,7 +40,7 @@ final class TranscriptionViewModel {
         SFSpeechRecognizer.requestAuthorization($0)
     }
     @ObservationIgnored
-    var summarize: (String) async throws -> String = SummarizationService().summarize
+    var summarize: (String, String) async throws -> String = SummarizationService().summarize
     @ObservationIgnored
     var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
 
@@ -108,7 +109,7 @@ final class TranscriptionViewModel {
         summaryState = .loading
 
         do {
-            let summary = try await summarize(text)
+            let summary = try await summarize(text, summaryPrompt)
             if summary.isEmpty {
                 summaryState = .failure("要約結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @State private var vocabularyStore = VocabularyStore()
     @State private var transcriberPreference = TranscriberPreference()
     @State private var openAIAPIKeyStore = OpenAIAPIKeyStore()
+    @State private var summaryPromptStore = SummaryPromptStore()
     @State private var showVocabulary = false
     @State private var showSettings = false
 
@@ -87,6 +88,7 @@ struct HomeView: View {
                 viewModel.liveTranscriberType = transcriberPreference.liveType
                 viewModel.postRecordingTranscriberType = transcriberPreference.postRecordingType
                 viewModel.openAIAPIKey = openAIAPIKeyStore.apiKey
+                viewModel.summaryPrompt = summaryPromptStore.prompt
                 viewModel.fetchAllEntries()
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
@@ -101,11 +103,14 @@ struct HomeView: View {
             .onChange(of: openAIAPIKeyStore.apiKey) { _, newKey in
                 viewModel.openAIAPIKey = newKey
             }
+            .onChange(of: summaryPromptStore.prompt) { _, newPrompt in
+                viewModel.summaryPrompt = newPrompt
+            }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
             }
             .sheet(isPresented: $showSettings) {
-                SettingsView(transcriberPreference: transcriberPreference, openAIAPIKeyStore: openAIAPIKeyStore)
+                SettingsView(transcriberPreference: transcriberPreference, openAIAPIKeyStore: openAIAPIKeyStore, summaryPromptStore: summaryPromptStore)
             }
             .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
                 if viewModel.isRecording {
@@ -118,7 +123,7 @@ struct HomeView: View {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey)
+                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey, summaryPrompt: summaryPromptStore.prompt)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
         }

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -144,7 +144,7 @@ struct RecordingModalView: View {
                 }
             }
             if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
-                viewModel.summarize = { _ in
+                viewModel.summarize = { _, _ in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
                 }

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @Bindable var transcriberPreference: TranscriberPreference
     @Bindable var openAIAPIKeyStore: OpenAIAPIKeyStore
+    @Bindable var summaryPromptStore: SummaryPromptStore
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -74,6 +75,22 @@ struct SettingsView: View {
                     Text("OpenAI API キー")
                 } footer: {
                     Text("Whisper API を使用するために必要です。API キーは端末内に保存されます。")
+                }
+
+                Section {
+                    TextEditor(text: $summaryPromptStore.prompt)
+                        .frame(minHeight: 100)
+                        .accessibilityIdentifier("settings.summaryPrompt")
+                    if summaryPromptStore.prompt != SummaryPromptStore.defaultPrompt {
+                        Button("デフォルトに戻す") {
+                            summaryPromptStore.resetToDefault()
+                        }
+                        .accessibilityIdentifier("settings.summaryPromptReset")
+                    }
+                } header: {
+                    Text("要約プロンプト")
+                } footer: {
+                    Text("書き起こしテキストの要約に使用するプロンプトです。書き起こしテキストはプロンプトの後に自動的に追加されます。")
                 }
             }
             .navigationTitle("設定")

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -7,6 +7,7 @@ struct TranscriptionView: View {
     var vocabularyWords: [String] = []
     var transcriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
+    var summaryPrompt: String = SummaryPromptStore.defaultPrompt
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
@@ -63,6 +64,7 @@ struct TranscriptionView: View {
             viewModel.vocabularyWords = vocabularyWords
             viewModel.transcriberType = transcriberType
             viewModel.openAIAPIKey = openAIAPIKey
+            viewModel.summaryPrompt = summaryPrompt
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
                 viewModel.transcribe = { _, _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
@@ -71,7 +73,7 @@ struct TranscriptionView: View {
                 viewModel.checkAuthorization = { .authorized }
             }
             if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
-                viewModel.summarize = { text in
+                viewModel.summarize = { text, _ in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
                 }

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -183,7 +183,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_triggersSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _ in "要約テスト結果" }
+        vm.summarize = { _, _ in "要約テスト結果" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
         vm.stopRecording()
@@ -212,7 +212,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_emptySummary_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _ in "" }
+        vm.summarize = { _, _ in "" }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
         vm.stopRecording()
@@ -227,7 +227,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
+        vm.summarize = { _, _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
         vm.isSummarizationAvailable = { true }
         vm.startRecording()
         vm.stopRecording()
@@ -245,7 +245,7 @@ struct HomeViewModelTests {
         vm.transcribe = { _, _, _, _, _ in
             throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
         }
-        vm.summarize = { _ in
+        vm.summarize = { _, _ in
             summarizeCalled = true
             return "この要約は呼ばれないはずです"
         }

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -24,7 +24,7 @@ struct SummarizationTests {
         let vm = TranscriptionViewModel()
         vm.checkAuthorization = { .authorized }
         vm.transcribe = { _, _, _, _, _ in "テスト書き起こし結果" }
-        vm.summarize = { _ in summarizeResult }
+        vm.summarize = { _, _ in summarizeResult }
         vm.isSummarizationAvailable = { available }
         return vm
     }
@@ -47,7 +47,7 @@ struct SummarizationTests {
     @Test func startSummarization_existingSummary_showsImmediately() async {
         let vm = makeViewModel()
         var summarizeCalled = false
-        vm.summarize = { _ in
+        vm.summarize = { _, _ in
             summarizeCalled = true
             return "新しい要約"
         }
@@ -82,7 +82,7 @@ struct SummarizationTests {
 
     @Test func startSummarization_error_showsFailure() async {
         let vm = makeViewModel()
-        vm.summarize = { _ in
+        vm.summarize = { _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
         }
         let recording = makeRecording(transcription: "テキスト")
@@ -99,7 +99,7 @@ struct SummarizationTests {
 
     @Test func startSummarization_failure_doesNotSaveSummary() async {
         let vm = makeViewModel()
-        vm.summarize = { _ in
+        vm.summarize = { _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
         let recording = makeRecording(transcription: "テキスト")

--- a/MindEcho/MindEchoTests/SummaryPromptStoreTests.swift
+++ b/MindEcho/MindEchoTests/SummaryPromptStoreTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+@testable import MindEcho
+
+@MainActor
+struct SummaryPromptStoreTests {
+    private func makeStore() -> (SummaryPromptStore, UserDefaults) {
+        let suiteName = "SummaryPromptStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let store = SummaryPromptStore(defaults: defaults)
+        return (store, defaults)
+    }
+
+    @Test func initialState_hasDefaultPrompt() {
+        let (store, _) = makeStore()
+        #expect(store.prompt == SummaryPromptStore.defaultPrompt)
+    }
+
+    @Test func setPrompt_persistsToUserDefaults() {
+        let suiteName = "SummaryPromptStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+
+        let store1 = SummaryPromptStore(defaults: defaults)
+        store1.prompt = "カスタムプロンプト"
+
+        let store2 = SummaryPromptStore(defaults: defaults)
+        #expect(store2.prompt == "カスタムプロンプト")
+    }
+
+    @Test func resetToDefault_restoresDefaultPrompt() {
+        let (store, _) = makeStore()
+        store.prompt = "変更されたプロンプト"
+        #expect(store.prompt != SummaryPromptStore.defaultPrompt)
+
+        store.resetToDefault()
+        #expect(store.prompt == SummaryPromptStore.defaultPrompt)
+    }
+
+    @Test func resetToDefault_persistsDefaultToUserDefaults() {
+        let suiteName = "SummaryPromptStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+
+        let store1 = SummaryPromptStore(defaults: defaults)
+        store1.prompt = "変更されたプロンプト"
+        store1.resetToDefault()
+
+        let store2 = SummaryPromptStore(defaults: defaults)
+        #expect(store2.prompt == SummaryPromptStore.defaultPrompt)
+    }
+
+    @Test func defaultPrompt_matchesHardcodedValue() {
+        #expect(SummaryPromptStore.defaultPrompt == "以下の書き起こしテキストを簡潔に要約してください。要約のみを出力し、余計な前置きは不要です。")
+    }
+}

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -91,6 +91,8 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `settings.liveTranscriber.{type}` — リアルタイム書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber）
 - `settings.postRecordingTranscriber.{type}` — 事後書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber | whisperAPI）
 - `settings.openAIAPIKey` — OpenAI API キー入力フィールド（SecureField）
+- `settings.summaryPrompt` — 要約プロンプト入力エリア（TextEditor）
+- `settings.summaryPromptReset` — 「デフォルトに戻す」ボタン（プロンプトがデフォルト値と異なる場合のみ表示）
 - `settings.closeButton` — シートを閉じるボタン（×アイコン）
 
 ### RecordingModalView


### PR DESCRIPTION
## 概要

要約プロンプトをハードコードから設定画面で変更可能にする機能を追加。`SummaryPromptStore` を新規作成し、`UserDefaults` で永続化する。

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] UI/デザイン変更
- [x] ドキュメント更新
- [x] テストの追加・修正
- [ ] ビルド・CI設定の変更
- [ ] その他

## 変更内容

- `SummaryPromptStore` を新規作成（`@Observable`、`UserDefaults` 永続化、DI 対応、`resetToDefault()` メソッド）
- `SummarizationService.summarize(text:)` → `summarize(text:prompt:)` にパラメータ追加
- `SettingsView` に「要約プロンプト」セクションを追加（`TextEditor` + 「デフォルトに戻す」ボタン）
- `HomeView` で `SummaryPromptStore` を `@State` で保持し、`SettingsView` / `TranscriptionView` / `HomeViewModel` に配線
- `HomeViewModel` / `TranscriptionViewModel` の `summarize` クロージャを `(String, String) async throws -> String` に変更
- `SummaryPromptStoreTests` を追加（初期値・永続化・リセット・デフォルト値一致）
- 既存テスト（`SummarizationTests`, `HomeViewModelTests`）を新しいシグネチャに更新
- `CLAUDE.md` / `docs/ui-test-design.md` を更新

## 影響範囲

- 対象画面: SettingsView（新セクション追加）
- 対象機能: 要約生成（カスタムプロンプト対応）

## スクリーンショット / 動画

なし

## テスト

- [x] ユニットテストを追加・更新した
- [ ] UIテストを追加・更新した
- [ ] シミュレータで動作確認した
- [ ] 実機で動作確認した

## チェックリスト

- [x] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [x] 不要なデバッグコード・print文を削除した
- [ ] 既存の機能にデグレがないことを確認した

## 関連Issue

Closes #101

## レビュアーへの補足

- `SummaryPromptStore` は `VocabularyStore` / `OpenAIAPIKeyStore` と同じパターン（`@Observable` + `UserDefaults` + DI）で実装
- デフォルトに戻すボタンはプロンプトがデフォルト値と異なる場合のみ表示される条件付きレンダリング

Generated with [Claude Code](https://claude.ai/code)
