### PR TITLE
feat: 要約エンジンを OpenAI API と切り替え可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ MindEchoApp (App Target)
 |-----------|------|--------|
 | **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, SummaryPromptStore, WhisperAPIService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `OpenAIAPIKeyStore`, `SummaryPromptStore`, `WhisperAPIService`, `VocabularyView` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, SummaryPromptStore, WhisperAPIService, SummarizerPreference, OpenAISummarizationService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `OpenAISummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `SummarizerPreference`, `SummarizerType`, `OpenAIAPIKeyStore`, `SummaryPromptStore`, `WhisperAPIService`, `VocabularyView` 等 |
 
 ### Design Principles
 
@@ -138,13 +138,22 @@ xcodebuild test \
 - `.whisperAPI` はポスト書き起こし専用。リアルタイム書き起こしのリストには表示しない
 
 
+### Summarizer Engine Preference
+
+要約エンジンの設定です。
+
+- `SummarizerPreference.type` — 要約に使用するエンジン（`onDevice`, `openAI`）
+- `.onDevice` — Apple Foundation Models（オンデバイス、デフォルト）
+- `.openAI` — OpenAI Chat Completions API（`gpt-4o-mini`、ネットワーク必須）
+- `OpenAIAPIKeyStore` の API キーは Whisper API と共有
+
 ### Data Model Relationships
 
 ```
 JournalEntry (1日1エントリ)
 └── recordings: [Recording]      (音声記録、連番管理)
     ├── transcription: String?   (書き起こしテキスト、SwiftData で永続化)
-    └── summary: String?         (要約テキスト、Apple Foundation Models で生成、SwiftData で永続化)
+    └── summary: String?         (要約テキスト、Apple Foundation Models または OpenAI API で生成、SwiftData で永続化)
 ```
 
 ## Definition of Done

--- a/MindEcho/MindEcho.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MindEcho/MindEcho.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "39f7921607a7f47fac984abd4a1a4c77d63a476b2cda8a8ddfee18973f095c3d",
+  "pins" : [
+    {
+      "identity" : "dswaveformimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dmrschmidt/DSWaveformImage",
+      "state" : {
+        "revision" : "a7a96cf4478c6fa084e76c175bcf7f4c9a38f80a",
+        "version" : "14.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
+++ b/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct OpenAISummarizationService: Sendable {
+    enum SummarizationError: LocalizedError {
+        case apiKeyMissing
+        case apiError(String)
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .apiKeyMissing:
+                "OpenAI API キーが設定されていません。設定画面から API キーを入力してください。"
+            case .apiError(let message):
+                "OpenAI API エラー: \(message)"
+            case .invalidResponse:
+                "OpenAI API から不正なレスポンスが返されました。"
+            }
+        }
+    }
+
+    private static let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+    func summarize(text: String, instruction: String, apiKey: String) async throws -> String {
+        guard !apiKey.isEmpty else {
+            throw SummarizationError.apiKeyMissing
+        }
+
+        let requestBody: [String: Any] = [
+            "model": "gpt-4o-mini",
+            "messages": [
+                ["role": "system", "content": instruction],
+                ["role": "user", "content": text],
+            ],
+            "temperature": 0.3,
+            "max_tokens": 300,
+        ]
+
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SummarizationError.invalidResponse
+        }
+
+        if httpResponse.statusCode != 200 {
+            if let errorBody = String(data: data, encoding: .utf8), !errorBody.isEmpty {
+                throw SummarizationError.apiError(errorBody)
+            }
+            throw SummarizationError.apiError("HTTP \(httpResponse.statusCode)")
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String
+        else {
+            throw SummarizationError.invalidResponse
+        }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
+++ b/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
@@ -37,6 +37,7 @@ struct OpenAISummarizationService: Sendable {
 
         var request = URLRequest(url: Self.endpoint)
         request.httpMethod = "POST"
+        request.timeoutInterval = 30
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
@@ -48,10 +49,26 @@ struct OpenAISummarizationService: Sendable {
         }
 
         if httpResponse.statusCode != 200 {
-            if let errorBody = String(data: data, encoding: .utf8), !errorBody.isEmpty {
-                throw SummarizationError.apiError(errorBody)
+            // OpenAI エラーレスポンスからユーザー向けメッセージを抽出
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let errorDict = json["error"] as? [String: Any],
+               let message = errorDict["message"] as? String,
+               !message.isEmpty {
+                throw SummarizationError.apiError(message)
             }
-            throw SummarizationError.apiError("HTTP \(httpResponse.statusCode)")
+
+            // ステータスコードに応じた定型文にフォールバック
+            let userMessage: String = switch httpResponse.statusCode {
+            case 401:
+                "API キーが無効か、認証に失敗しました。設定を確認してください。"
+            case 429:
+                "リクエストが多すぎます。しばらく時間をおいてから再試行してください。"
+            case 500...599:
+                "OpenAI API 側でエラーが発生しました。時間をおいて再試行してください。"
+            default:
+                "HTTP \(httpResponse.statusCode) エラーが発生しました。"
+            }
+            throw SummarizationError.apiError(userMessage)
         }
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -15,4 +15,24 @@ struct SummarizationService {
         }
         return false
     }
+
+    // MARK: - Dispatch (共通エントリポイント)
+
+    static func summarize(text: String, instruction: String, type: SummarizerType, apiKey: String) async throws -> String {
+        switch type {
+        case .onDevice:
+            try await SummarizationService().summarize(text: text, instruction: instruction)
+        case .openAI:
+            try await OpenAISummarizationService().summarize(text: text, instruction: instruction, apiKey: apiKey)
+        }
+    }
+
+    static func isAvailable(type: SummarizerType, apiKey: String) -> Bool {
+        switch type {
+        case .onDevice:
+            Self.isAvailable
+        case .openAI:
+            !apiKey.isEmpty
+        }
+    }
 }

--- a/MindEcho/MindEcho/Services/SummarizerPreference.swift
+++ b/MindEcho/MindEcho/Services/SummarizerPreference.swift
@@ -26,7 +26,7 @@ enum SummarizerType: String, CaseIterable, Sendable {
 
 @Observable
 final class SummarizerPreference {
-    private static let key = "summarizerType"
+    private static let defaultKey = "summarizerType"
 
     private let defaults: UserDefaults
     private let keyName: String
@@ -35,7 +35,7 @@ final class SummarizerPreference {
         didSet { defaults.set(type.rawValue, forKey: keyName) }
     }
 
-    init(defaults: UserDefaults = .standard, key: String = key) {
+    init(defaults: UserDefaults = .standard, key: String = defaultKey) {
         self.defaults = defaults
         self.keyName = key
         self.type = defaults.string(forKey: key)

--- a/MindEcho/MindEcho/Services/SummarizerPreference.swift
+++ b/MindEcho/MindEcho/Services/SummarizerPreference.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Observation
+
+enum SummarizerType: String, CaseIterable, Sendable {
+    case onDevice
+    case openAI
+
+    var displayName: String {
+        switch self {
+        case .onDevice:
+            "Apple Foundation Models"
+        case .openAI:
+            "OpenAI API"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .onDevice:
+            "オンデバイスで動作（ネットワーク不要）"
+        case .openAI:
+            "OpenAI Chat Completions API（ネットワーク必須・テキストが外部送信されます）"
+        }
+    }
+}
+
+@Observable
+final class SummarizerPreference {
+    private static let key = "summarizerType"
+
+    private let defaults: UserDefaults
+    private let keyName: String
+
+    var type: SummarizerType {
+        didSet { defaults.set(type.rawValue, forKey: keyName) }
+    }
+
+    init(defaults: UserDefaults = .standard, key: String = key) {
+        self.defaults = defaults
+        self.keyName = key
+        self.type = defaults.string(forKey: key)
+            .flatMap(SummarizerType.init(rawValue:)) ?? .onDevice
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -39,15 +39,20 @@ class HomeViewModel {
     var postRecordingTranscriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
     var summaryInstruction: String = SummaryPromptStore.defaultInstruction
+    var summarizerType: SummarizerType = .onDevice
 
     @ObservationIgnored
     var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
         try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
-    var summarize: (String, String) async throws -> String = SummarizationService().summarize
+    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+        try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
+    }
     @ObservationIgnored
-    var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
+    var isSummarizationAvailable: (SummarizerType, String) -> Bool = { type, apiKey in
+        SummarizationService.isAvailable(type: type, apiKey: apiKey)
+    }
 
     private let modelContext: ModelContext
     private var audioRecorder: any AudioRecording
@@ -208,13 +213,13 @@ class HomeViewModel {
             summaryState = .success(existing)
             return
         }
-        guard isSummarizationAvailable() else {
+        guard isSummarizationAvailable(summarizerType, openAIAPIKey) else {
             summaryState = .unavailable
             return
         }
         summaryState = .loading
         do {
-            let summary = try await summarize(text, summaryInstruction)
+            let summary = try await summarize(text, summaryInstruction, summarizerType, openAIAPIKey)
             if summary.isEmpty {
                 summaryState = .failure("要約結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -26,6 +26,7 @@ final class TranscriptionViewModel {
     var transcriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
     var summaryInstruction: String = SummaryPromptStore.defaultInstruction
+    var summarizerType: SummarizerType = .onDevice
 
     @ObservationIgnored
     var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
@@ -40,9 +41,13 @@ final class TranscriptionViewModel {
         SFSpeechRecognizer.requestAuthorization($0)
     }
     @ObservationIgnored
-    var summarize: (String, String) async throws -> String = SummarizationService().summarize
+    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+        try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
+    }
     @ObservationIgnored
-    var isSummarizationAvailable: () -> Bool = { SummarizationService.isAvailable }
+    var isSummarizationAvailable: (SummarizerType, String) -> Bool = { type, apiKey in
+        SummarizationService.isAvailable(type: type, apiKey: apiKey)
+    }
 
     func retryTranscription(recording: Recording) async {
         recording.transcription = nil
@@ -101,7 +106,7 @@ final class TranscriptionViewModel {
             return
         }
 
-        guard isSummarizationAvailable() else {
+        guard isSummarizationAvailable(summarizerType, openAIAPIKey) else {
             summaryState = .unavailable
             return
         }
@@ -109,7 +114,7 @@ final class TranscriptionViewModel {
         summaryState = .loading
 
         do {
-            let summary = try await summarize(text, summaryInstruction)
+            let summary = try await summarize(text, summaryInstruction, summarizerType, openAIAPIKey)
             if summary.isEmpty {
                 summaryState = .failure("要約結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -10,6 +10,7 @@ struct HomeView: View {
     @State private var shareItems: [Any]?
     @State private var vocabularyStore = VocabularyStore()
     @State private var transcriberPreference = TranscriberPreference()
+    @State private var summarizerPreference = SummarizerPreference()
     @State private var openAIAPIKeyStore = OpenAIAPIKeyStore()
     @State private var summaryPromptStore = SummaryPromptStore()
     @State private var showVocabulary = false
@@ -89,6 +90,7 @@ struct HomeView: View {
                 viewModel.postRecordingTranscriberType = transcriberPreference.postRecordingType
                 viewModel.openAIAPIKey = openAIAPIKeyStore.apiKey
                 viewModel.summaryInstruction = summaryPromptStore.instruction
+                viewModel.summarizerType = summarizerPreference.type
                 viewModel.fetchAllEntries()
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
@@ -106,11 +108,14 @@ struct HomeView: View {
             .onChange(of: summaryPromptStore.instruction) { _, newInstruction in
                 viewModel.summaryInstruction = newInstruction
             }
+            .onChange(of: summarizerPreference.type) { _, newType in
+                viewModel.summarizerType = newType
+            }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
             }
             .sheet(isPresented: $showSettings) {
-                SettingsView(transcriberPreference: transcriberPreference, openAIAPIKeyStore: openAIAPIKeyStore, summaryPromptStore: summaryPromptStore)
+                SettingsView(transcriberPreference: transcriberPreference, summarizerPreference: summarizerPreference, openAIAPIKeyStore: openAIAPIKeyStore, summaryPromptStore: summaryPromptStore)
             }
             .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
                 if viewModel.isRecording {
@@ -123,7 +128,7 @@ struct HomeView: View {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey, summaryInstruction: summaryPromptStore.instruction)
+                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey, summaryInstruction: summaryPromptStore.instruction, summarizerType: summarizerPreference.type)
                     .accessibilityIdentifier("home.transcriptionSheet")
             }
         }

--- a/MindEcho/MindEcho/Views/RecordingModalView.swift
+++ b/MindEcho/MindEcho/Views/RecordingModalView.swift
@@ -144,11 +144,11 @@ struct RecordingModalView: View {
                 }
             }
             if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
-                viewModel.summarize = { _, _ in
+                viewModel.summarize = { _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
                 }
-                viewModel.isSummarizationAvailable = { true }
+                viewModel.isSummarizationAvailable = { _, _ in true }
             }
             viewModel.startRecording()
         }

--- a/MindEcho/MindEcho/Views/SettingsView.swift
+++ b/MindEcho/MindEcho/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Bindable var transcriberPreference: TranscriberPreference
+    @Bindable var summarizerPreference: SummarizerPreference
     @Bindable var openAIAPIKeyStore: OpenAIAPIKeyStore
     @Bindable var summaryPromptStore: SummaryPromptStore
     @Environment(\.dismiss) private var dismiss
@@ -66,6 +67,34 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    ForEach(SummarizerType.allCases, id: \.self) { type in
+                        Button {
+                            summarizerPreference.type = type
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(type.displayName)
+                                        .foregroundStyle(.primary)
+                                    Text(type.description)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                if summarizerPreference.type == type {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(.blue)
+                                }
+                            }
+                        }
+                        .accessibilityIdentifier("settings.summarizer.\(type.rawValue)")
+                    }
+                } header: {
+                    Text("要約エンジン")
+                } footer: {
+                    Text("書き起こしテキストの要約に使用するエンジンです。OpenAI API はネットワーク接続が必要で、テキストが OpenAI サーバーに送信されます。")
+                }
+
+                Section {
                     SecureField("sk-...", text: $openAIAPIKeyStore.apiKey)
                         .textContentType(.password)
                         .autocorrectionDisabled()
@@ -74,7 +103,7 @@ struct SettingsView: View {
                 } header: {
                     Text("OpenAI API キー")
                 } footer: {
-                    Text("Whisper API を使用するために必要です。API キーは端末内に保存されます。")
+                    Text("Whisper API および OpenAI 要約を使用するために必要です。API キーは端末内に保存されます。")
                 }
 
                 Section {

--- a/MindEcho/MindEcho/Views/TranscriptionView.swift
+++ b/MindEcho/MindEcho/Views/TranscriptionView.swift
@@ -8,6 +8,7 @@ struct TranscriptionView: View {
     var transcriberType: TranscriberType = .speechTranscriber
     var openAIAPIKey: String = ""
     var summaryInstruction: String = SummaryPromptStore.defaultInstruction
+    var summarizerType: SummarizerType = .onDevice
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = TranscriptionViewModel()
 
@@ -65,6 +66,7 @@ struct TranscriptionView: View {
             viewModel.transcriberType = transcriberType
             viewModel.openAIAPIKey = openAIAPIKey
             viewModel.summaryInstruction = summaryInstruction
+            viewModel.summarizerType = summarizerType
             if ProcessInfo.processInfo.arguments.contains("--mock-transcription") {
                 viewModel.transcribe = { _, _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(500))
@@ -73,11 +75,11 @@ struct TranscriptionView: View {
                 viewModel.checkAuthorization = { .authorized }
             }
             if ProcessInfo.processInfo.arguments.contains("--mock-summarization") {
-                viewModel.summarize = { _, _ in
+                viewModel.summarize = { _, _, _, _ in
                     try await Task.sleep(for: .milliseconds(300))
                     return "これはモックの要約結果です。"
                 }
-                viewModel.isSummarizationAvailable = { true }
+                viewModel.isSummarizationAvailable = { _, _ in true }
             }
             await viewModel.startTranscription(recording: recording)
         }

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -183,8 +183,8 @@ struct HomeViewModelTests {
     @Test func startTranscription_triggersSummarization() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _, _ in "要約テスト結果" }
-        vm.isSummarizationAvailable = { true }
+        vm.summarize = { _, _, _, _ in "要約テスト結果" }
+        vm.isSummarizationAvailable = { _, _ in true }
         vm.startRecording()
         vm.stopRecording()
 
@@ -198,7 +198,7 @@ struct HomeViewModelTests {
     @Test func startTranscription_summarizationUnavailable_setsUnavailableState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.isSummarizationAvailable = { false }
+        vm.isSummarizationAvailable = { _, _ in false }
         vm.startRecording()
         vm.stopRecording()
 
@@ -212,8 +212,8 @@ struct HomeViewModelTests {
     @Test func startTranscription_emptySummary_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _, _ in "" }
-        vm.isSummarizationAvailable = { true }
+        vm.summarize = { _, _, _, _ in "" }
+        vm.isSummarizationAvailable = { _, _ in true }
         vm.startRecording()
         vm.stopRecording()
 
@@ -227,8 +227,8 @@ struct HomeViewModelTests {
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _, _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
-        vm.isSummarizationAvailable = { true }
+        vm.summarize = { _, _, _, _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
+        vm.isSummarizationAvailable = { _, _ in true }
         vm.startRecording()
         vm.stopRecording()
 
@@ -245,11 +245,11 @@ struct HomeViewModelTests {
         vm.transcribe = { _, _, _, _, _ in
             throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "書き起こしエラー"])
         }
-        vm.summarize = { _, _ in
+        vm.summarize = { _, _, _, _ in
             summarizeCalled = true
             return "この要約は呼ばれないはずです"
         }
-        vm.isSummarizationAvailable = { true }
+        vm.isSummarizationAvailable = { _, _ in true }
         vm.startRecording()
         vm.stopRecording()
 
@@ -268,7 +268,7 @@ struct HomeViewModelTests {
             receivedWords = words
             return "テスト"
         }
-        vm.isSummarizationAvailable = { false }
+        vm.isSummarizationAvailable = { _, _ in false }
         vm.vocabularyWords = ["MindEcho", "SwiftUI"]
         vm.startRecording()
         vm.stopRecording()

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -24,8 +24,8 @@ struct SummarizationTests {
         let vm = TranscriptionViewModel()
         vm.checkAuthorization = { .authorized }
         vm.transcribe = { _, _, _, _, _ in "テスト書き起こし結果" }
-        vm.summarize = { _, _ in summarizeResult }
-        vm.isSummarizationAvailable = { available }
+        vm.summarize = { _, _, _, _ in summarizeResult }
+        vm.isSummarizationAvailable = { _, _ in available }
         return vm
     }
 
@@ -47,7 +47,7 @@ struct SummarizationTests {
     @Test func startSummarization_existingSummary_showsImmediately() async {
         let vm = makeViewModel()
         var summarizeCalled = false
-        vm.summarize = { _, _ in
+        vm.summarize = { _, _, _, _ in
             summarizeCalled = true
             return "新しい要約"
         }
@@ -82,7 +82,7 @@ struct SummarizationTests {
 
     @Test func startSummarization_error_showsFailure() async {
         let vm = makeViewModel()
-        vm.summarize = { _, _ in
+        vm.summarize = { _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
         }
         let recording = makeRecording(transcription: "テキスト")
@@ -99,7 +99,7 @@ struct SummarizationTests {
 
     @Test func startSummarization_failure_doesNotSaveSummary() async {
         let vm = makeViewModel()
-        vm.summarize = { _, _ in
+        vm.summarize = { _, _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "エラー"])
         }
         let recording = makeRecording(transcription: "テキスト")
@@ -131,5 +131,48 @@ struct SummarizationTests {
         await vm.startTranscription(recording: recording)
 
         #expect(vm.summaryState == .idle)
+    }
+
+    // MARK: - OpenAI Summarization Tests
+
+    @Test func startSummarization_openAI_passesSummarizerTypeAndKey() async {
+        let vm = makeViewModel()
+        var receivedType: SummarizerType?
+        var receivedKey: String?
+        vm.summarize = { _, _, type, key in
+            receivedType = type
+            receivedKey = key
+            return "OpenAI要約結果"
+        }
+        vm.isSummarizationAvailable = { _, _ in true }
+        vm.summarizerType = .openAI
+        vm.openAIAPIKey = "sk-test-key"
+
+        let recording = makeRecording(transcription: "テキスト")
+        await vm.startTranscription(recording: recording)
+
+        #expect(receivedType == .openAI)
+        #expect(receivedKey == "sk-test-key")
+        #expect(vm.summaryState == .success("OpenAI要約結果"))
+    }
+
+    @Test func startSummarization_openAI_unavailableWithoutKey() async {
+        let vm = makeViewModel()
+        vm.isSummarizationAvailable = { summarizerType, openAIAPIKey in
+            switch summarizerType {
+            case .onDevice:
+                true
+            case .openAI:
+                !openAIAPIKey.isEmpty
+            }
+        }
+        vm.summarizerType = .openAI
+        vm.openAIAPIKey = ""
+
+        let recording = makeRecording(transcription: "テキスト")
+        await vm.startTranscription(recording: recording)
+
+        #expect(vm.summaryState == .unavailable)
+        #expect(recording.summary == nil)
     }
 }

--- a/MindEcho/MindEchoTests/SummarizerPreferenceTests.swift
+++ b/MindEcho/MindEchoTests/SummarizerPreferenceTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import MindEcho
+
+@MainActor
+struct SummarizerPreferenceTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "SummarizerPreferenceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return defaults
+    }
+
+    @Test func defaultType_isOnDevice() {
+        let defaults = makeDefaults()
+        let pref = SummarizerPreference(defaults: defaults)
+        #expect(pref.type == .onDevice)
+    }
+
+    @Test func setType_persistsToUserDefaults() {
+        let defaults = makeDefaults()
+        let pref = SummarizerPreference(defaults: defaults)
+
+        pref.type = .openAI
+
+        #expect(defaults.string(forKey: "summarizerType") == "openAI")
+    }
+
+    @Test func initFromPersistedValues_restoresType() {
+        let defaults = makeDefaults()
+        defaults.set("openAI", forKey: "summarizerType")
+
+        let pref = SummarizerPreference(defaults: defaults)
+
+        #expect(pref.type == .openAI)
+    }
+
+    @Test func invalidPersistedValue_defaultsToOnDevice() {
+        let defaults = makeDefaults()
+        defaults.set("invalidValue", forKey: "summarizerType")
+
+        let pref = SummarizerPreference(defaults: defaults)
+
+        #expect(pref.type == .onDevice)
+    }
+
+    @Test func summarizerType_displayNames() {
+        #expect(SummarizerType.onDevice.displayName == "Apple Foundation Models")
+        #expect(SummarizerType.openAI.displayName == "OpenAI API")
+    }
+
+    @Test func summarizerType_allCases() {
+        #expect(SummarizerType.allCases.count == 2)
+        #expect(SummarizerType.allCases.contains(.onDevice))
+        #expect(SummarizerType.allCases.contains(.openAI))
+    }
+}

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -127,7 +127,7 @@ struct TranscriptionViewModelTests {
             callCount += 1
             return "書き起こし結果\(callCount)"
         }
-        vm.isSummarizationAvailable = { false }
+        vm.isSummarizationAvailable = { _, _ in false }
 
         let recording = makeRecording()
         await vm.startTranscription(recording: recording)

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -90,6 +90,7 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 
 - `settings.liveTranscriber.{type}` — リアルタイム書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber）
 - `settings.postRecordingTranscriber.{type}` — 事後書き起こしエンジン選択ボタン（type = speechTranscriber | dictationTranscriber | whisperAPI）
+- `settings.summarizer.{type}` — 要約エンジン選択ボタン（type = onDevice | openAI）
 - `settings.openAIAPIKey` — OpenAI API キー入力フィールド（SecureField）
 - `settings.summaryPrompt` — 要約プロンプト編集エリア（TextEditor）
 - `settings.summaryPromptResetButton` — 要約プロンプトをデフォルトに戻すボタン


### PR DESCRIPTION
## Summary
- 要約エンジンを Apple Foundation Models（オンデバイス）と OpenAI API（gpt-4o-mini）で切り替えられる機能を追加
- 設定画面に「要約エンジン」セクションを新設し、ユーザーが選択可能に
- 既存の書き起こしエンジン切替パターン（TranscriberPreference）に倣った設計で、SummarizerType / SummarizerPreference を導入

## Changes
- **新規**: `SummarizerPreference.swift` — `SummarizerType` enum（`.onDevice` / `.openAI`）と `@Observable` な設定クラス
- **新規**: `OpenAISummarizationService.swift` — OpenAI Chat Completions API による要約サービス
- **修正**: ViewModel（Home / Transcription）の `summarize` / `isSummarizationAvailable` クロージャシグネチャを拡張し、エンジン種別とAPIキーを受け取るように変更
- **修正**: SettingsView に要約エンジン選択UIを追加、APIキーセクションの説明文を更新
- **修正**: HomeView / TranscriptionView / RecordingModalView に設定の注入・同期を追加
- **テスト**: 既存テストのシグネチャ更新 + OpenAIパステスト2件 + SummarizerPreferenceTests 6件を新規追加（全60テスト通過）
- **ドキュメント**: CLAUDE.md、docs/ui-test-design.md を更新

## Test plan
- [x] `xcodebuild build` エラーなし
- [x] MindEchoTests 全60テスト通過（SummarizationTests 11件、HomeViewModelTests 16件、SummarizerPreferenceTests 6件含む）
- [ ] シミュレータで設定画面から要約エンジンを切り替えられることを確認
- [ ] OpenAI API キー設定後、OpenAI 要約が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)