### PR TITLE
fix: resolve iPhone simulator dynamically in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,14 @@ on:
       - 'MindEcho/**'
       - 'Packages/**'
       - 'MindEcho.xcworkspace/**'
+      - 'scripts/select-ios-simulator.sh'
       - '.github/workflows/test.yml'
   pull_request:
     paths:
       - 'MindEcho/**'
       - 'Packages/**'
       - 'MindEcho.xcworkspace/**'
+      - 'scripts/select-ios-simulator.sh'
       - '.github/workflows/test.yml'
   workflow_dispatch:
 
@@ -24,7 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DESTINATION: 'platform=iOS Simulator,name=iPhone 17'
   WORKSPACE: MindEcho.xcworkspace
 
 jobs:
@@ -34,6 +35,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+
+      - name: Resolve iPhone simulator destination
+        run: |
+          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
+          echo "Using destination: $DESTINATION"
 
       - name: Build for Testing
         run: |
@@ -58,6 +65,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve iPhone simulator destination
+        run: |
+          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
+          echo "Using destination: $DESTINATION"
+
       - name: Download Build Products
         uses: actions/download-artifact@v4
         with:
@@ -80,6 +93,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+
+      - name: Resolve iPhone simulator destination
+        run: |
+          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
+          echo "Using destination: $DESTINATION"
 
       - name: Download Build Products
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Resolve iPhone simulator destination
         run: |
-          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          DESTINATION="$(bash scripts/select-ios-simulator.sh)"
           echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
           echo "Using destination: $DESTINATION"
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Resolve iPhone simulator destination
         run: |
-          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          DESTINATION="$(bash scripts/select-ios-simulator.sh)"
           echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
           echo "Using destination: $DESTINATION"
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Resolve iPhone simulator destination
         run: |
-          DESTINATION="$(./scripts/select-ios-simulator.sh)"
+          DESTINATION="$(bash scripts/select-ios-simulator.sh)"
           echo "DESTINATION=$DESTINATION" >> "$GITHUB_ENV"
           echo "Using destination: $DESTINATION"
 

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -14,55 +14,54 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-destination="$(
-  xcrun simctl list devices available -j \
-    | jq -r '
-        def build_candidate($runtime_key; $device):
-          {
-            destination: ("platform=iOS Simulator,id=" + $device.udid),
-            name: $device.name,
-            runtime_version: (
-              $runtime_key
-              | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
-              | split("-")
-              | map(tonumber? // 0)
-            ),
-            device_number: (
-              if ($device.name | test("^iPhone [0-9]+$")) then
-                ($device.name | capture("^iPhone (?<n>[0-9]+)$").n | tonumber)
-              else
-                0
-              end
-            )
-          };
+available_devices_json="$(xcrun simctl list devices available -j)"
 
-        [
-          .devices
-          | to_entries[]
-          | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
-          | .key as $runtime_key
-          | .value[]
-          | select(.isAvailable == true)
-          | select(.name | startswith("iPhone"))
-          | build_candidate($runtime_key; .)
-        ] as $all_candidates
-        |
-        (
-          [
-            $all_candidates[]
-            | select(.name | test("^iPhone [0-9]+$"))
-          ]
-        ) as $standard_candidates
-        |
-        if ($standard_candidates | length) > 0 then
-          $standard_candidates
-        else
-          $all_candidates
-        end
-        | sort_by([.runtime_version, .device_number, .name])
-        | last
-        | .destination // empty
-      '
+destination="$(
+  printf '%s\n' "$available_devices_json" | jq -r '
+    def build_candidate($runtime_key; $device):
+      {
+        destination: ("platform=iOS Simulator,id=" + $device.udid),
+        name: $device.name,
+        runtime_version: (
+          $runtime_key
+          | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
+          | split("-")
+          | map(tonumber? // 0)
+        ),
+        device_number: (
+          if ($device.name | test("^iPhone [0-9]+$")) then
+            ($device.name | capture("^iPhone (?<n>[0-9]+)$").n | tonumber)
+          else
+            0
+          end
+        )
+      };
+
+    [
+      .devices
+      | to_entries[]
+      | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+      | .key as $runtime_key
+      | .value[]
+      | select(.isAvailable == true)
+      | select(.name | startswith("iPhone"))
+      | build_candidate($runtime_key; .)
+    ] as $all_candidates
+    |
+    [
+      $all_candidates[]
+      | select(.name | test("^iPhone [0-9]+$"))
+    ] as $standard_candidates
+    |
+    if ($standard_candidates | length) > 0 then
+      $standard_candidates
+    else
+      $all_candidates
+    end
+    | sort_by([.runtime_version, .device_number, .name])
+    | last
+    | .destination // empty
+  '
 )"
 
 if [ -z "${destination}" ]; then

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+# Prints a single xcodebuild destination string for an available iPhone simulator,
+# for example: platform=iOS Simulator,id=24AB410C-2DE0-4DE3-8BE7-F920A29960E7
 if ! command -v xcrun >/dev/null 2>&1; then
   echo "xcrun is required" >&2
   exit 1
@@ -15,27 +17,42 @@ fi
 destination="$(
   xcrun simctl list devices available -j \
     | jq -r '
-        [
-          .devices
-          | to_entries[]
-          | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
-          | .key as $runtime_key
-          | .value[]
-          | select(.isAvailable == true)
-          | select(.name | startswith("iPhone"))
-          | {
-              destination: ("platform=iOS Simulator,id=" + .udid),
-              name,
-              runtime_version: (
-                $runtime_key
-                | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
-                | split("-")
-                | map(tonumber? // 0)
-              )
-            }
-        ]
-        | sort_by([.runtime_version, .name])
-        | last
+        def candidates:
+          [
+            .devices
+            | to_entries[]
+            | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+            | .key as $runtime_key
+            | .value[]
+            | select(.isAvailable == true)
+            | select(.name | startswith("iPhone"))
+            | {
+                destination: ("platform=iOS Simulator,id=" + .udid),
+                name,
+                runtime_version: (
+                  $runtime_key
+                  | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
+                  | split("-")
+                  | map(tonumber? // 0)
+                )
+              }
+          ];
+
+        def pick_device($devices):
+          $devices
+          | sort_by([.runtime_version, .name])
+          | last;
+
+        (
+          candidates
+          | map(select(.name | test("^iPhone [0-9]+$")))
+        ) as $plain_iphones
+        |
+        if ($plain_iphones | length) > 0 then
+          pick_device($plain_iphones)
+        else
+          pick_device(candidates)
+        end
         | .destination // empty
       '
 )"

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -34,10 +34,9 @@ destination="$(
               )
             }
         ]
-        | sort_by(.name)
-        | sort_by(.runtime_version)
-        | reverse
-        | .[0].destination // empty
+        | sort_by([.runtime_version, .name])
+        | last
+        | .destination // empty
       '
 )"
 

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -17,49 +17,50 @@ fi
 destination="$(
   xcrun simctl list devices available -j \
     | jq -r '
-        def candidates:
-          [
-            .devices
-            | to_entries[]
-            | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
-            | .key as $runtime_key
-            | .value[]
-            | select(.isAvailable == true)
-            | select(.name | startswith("iPhone"))
-            | {
-                destination: ("platform=iOS Simulator,id=" + .udid),
-                name,
-                runtime_version: (
-                  $runtime_key
-                  | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
-                  | split("-")
-                  | map(tonumber? // 0)
-                ),
-                device_number: (
-                  (
-                    .name
-                    | capture("^iPhone (?<n>[0-9]+)$").n
-                    | tonumber
-                  ) // 0
-                )
-              }
-          ];
+        def build_candidate($runtime_key; $device):
+          {
+            destination: ("platform=iOS Simulator,id=" + $device.udid),
+            name: $device.name,
+            runtime_version: (
+              $runtime_key
+              | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
+              | split("-")
+              | map(tonumber? // 0)
+            ),
+            device_number: (
+              (
+                $device.name
+                | capture("^iPhone (?<n>[0-9]+)$").n
+                | tonumber
+              ) // 0
+            )
+          };
 
-        def pick_device($devices):
-          $devices
-          | sort_by([.runtime_version, .device_number, .name])
-          | last;
-
-        (
-          candidates
-          | map(select(.name | test("^iPhone [0-9]+$")))
-        ) as $plain_iphones
+        [
+          .devices
+          | to_entries[]
+          | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+          | .key as $runtime_key
+          | .value[]
+          | select(.isAvailable == true)
+          | select(.name | startswith("iPhone"))
+          | build_candidate($runtime_key; .)
+        ] as $all_candidates
         |
-        if ($plain_iphones | length) > 0 then
-          pick_device($plain_iphones)
+        (
+          [
+            $all_candidates[]
+            | select(.name | test("^iPhone [0-9]+$"))
+          ]
+        ) as $standard_candidates
+        |
+        if ($standard_candidates | length) > 0 then
+          $standard_candidates
         else
-          pick_device(candidates)
+          $all_candidates
         end
+        | sort_by([.runtime_version, .device_number, .name])
+        | last
         | .destination // empty
       '
 )"

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "xcrun is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+destination="$(
+  xcrun simctl list devices available -j \
+    | jq -r '
+        [
+          .devices
+          | to_entries[]
+          | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+          | .key as $runtime_key
+          | .value[]
+          | select(.isAvailable == true)
+          | select(.name | startswith("iPhone"))
+          | {
+              destination: ("platform=iOS Simulator,id=" + .udid),
+              name,
+              runtime_version: (
+                $runtime_key
+                | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
+                | split("-")
+                | map(tonumber? // 0)
+              )
+            }
+        ]
+        | sort_by(.name)
+        | sort_by(.runtime_version)
+        | reverse
+        | .[0].destination // empty
+      '
+)"
+
+if [ -z "${destination}" ]; then
+  echo "No available iPhone simulator found" >&2
+  exit 1
+fi
+
+echo "${destination}"

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -34,13 +34,20 @@ destination="$(
                   | sub("^com.apple.CoreSimulator.SimRuntime.iOS-"; "")
                   | split("-")
                   | map(tonumber? // 0)
+                ),
+                device_number: (
+                  (
+                    .name
+                    | capture("^iPhone (?<n>[0-9]+)$").n
+                    | tonumber
+                  ) // 0
                 )
               }
           ];
 
         def pick_device($devices):
           $devices
-          | sort_by([.runtime_version, .name])
+          | sort_by([.runtime_version, .device_number, .name])
           | last;
 
         (

--- a/scripts/select-ios-simulator.sh
+++ b/scripts/select-ios-simulator.sh
@@ -28,11 +28,11 @@ destination="$(
               | map(tonumber? // 0)
             ),
             device_number: (
-              (
-                $device.name
-                | capture("^iPhone (?<n>[0-9]+)$").n
-                | tonumber
-              ) // 0
+              if ($device.name | test("^iPhone [0-9]+$")) then
+                ($device.name | capture("^iPhone (?<n>[0-9]+)$").n | tonumber)
+              else
+                0
+              end
             )
           };
 


### PR DESCRIPTION
## Summary
- add a shell script to select an available iPhone simulator dynamically from simctl
- update the Test workflow to resolve DESTINATION at runtime in each job
- trigger the workflow when the new script changes

## Testing
- bash -n scripts/select-ios-simulator.sh