### PR TITLE
feat: swift-format を導入しコードスタイルを統一

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,8 @@
+{
+  "version" : 1,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "tabWidth" : 4,
+  "lineLength" : 120
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ MindEchoApp (App Target)
 
 ```
 mind-echo/
+├── .swift-format               # swift-format 設定ファイル
 ├── docs/                       # 設計ドキュメント
 ├── Packages/
 │   ├── MindEchoCore/          # ドメインモデル、日付、ファイル管理
@@ -104,6 +105,12 @@ xcodebuild test \
 ```
 
 ## Coding Guidelines
+
+### swift-format
+
+Apple 公式の [swift-format](https://github.com/swiftlang/swift-format) を使用してコードスタイルを統一しています。設定はプロジェクトルートの `.swift-format` を参照。
+
+- コミット前にフォーマットを適用すること: `xcrun swift-format format --in-place --recursive --configuration .swift-format <対象ディレクトリ>`
 
 ### Swift Concurrency
 

--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -132,7 +132,8 @@ struct MindEchoApp: App {
         let frameCount = AVAudioFrameCount(sampleRate * duration)
 
         guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1),
-              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)
+        else { return }
         buffer.frameLength = frameCount
 
         let settings: [String: Any] = [
@@ -142,7 +143,8 @@ struct MindEchoApp: App {
             AVEncoderAudioQualityKey: AVAudioQuality.low.rawValue,
         ]
         do {
-            let file = try AVAudioFile(forWriting: url, settings: settings, commonFormat: .pcmFormatFloat32, interleaved: false)
+            let file = try AVAudioFile(
+                forWriting: url, settings: settings, commonFormat: .pcmFormatFloat32, interleaved: false)
             try file.write(from: buffer)
         } catch {
             // Fallback: create as CAF/PCM

--- a/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Mocks/MockLiveTranscriptionService.swift
@@ -4,7 +4,9 @@ import Observation
 
 @Observable
 class MockLiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
-    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber)
+        -> AsyncThrowingStream<String, Error>
+    {
         AsyncThrowingStream { continuation in
             Task {
                 // Initial delay must be long enough for XCTest to detect the placeholder state.

--- a/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/LiveTranscriptionService.swift
@@ -3,7 +3,9 @@ import Foundation
 import Speech
 
 protocol LiveTranscribing: Sendable {
-    func start(locale: Locale, contextualStrings: [String], transcriberType: TranscriberType) -> AsyncThrowingStream<String, Error>
+    func start(locale: Locale, contextualStrings: [String], transcriberType: TranscriberType) -> AsyncThrowingStream<
+        String, Error
+    >
     func feedAudioBuffer(_ buffer: AVAudioPCMBuffer, format: AVAudioFormat)
     func stop()
 }
@@ -22,7 +24,9 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
     private var isSetupComplete = false
     nonisolated(unsafe) private var lock = os_unfair_lock()
 
-    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber) -> AsyncThrowingStream<String, Error> {
+    func start(locale: Locale, contextualStrings: [String] = [], transcriberType: TranscriberType = .speechTranscriber)
+        -> AsyncThrowingStream<String, Error>
+    {
         switch transcriberType {
         case .speechTranscriber, .whisperAPI:
             startWithSpeechTranscriber(locale: locale, contextualStrings: contextualStrings)
@@ -31,7 +35,9 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
         }
     }
 
-    private func startWithSpeechTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error> {
+    private func startWithSpeechTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<
+        String, Error
+    > {
         AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -97,7 +103,9 @@ final class LiveTranscriptionService: LiveTranscribing, @unchecked Sendable {
         }
     }
 
-    private func startWithDictationTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<String, Error> {
+    private func startWithDictationTranscriber(locale: Locale, contextualStrings: [String]) -> AsyncThrowingStream<
+        String, Error
+    > {
         AsyncThrowingStream { continuation in
             Task {
                 do {

--- a/MindEcho/MindEcho/Services/TranscriberPreference.swift
+++ b/MindEcho/MindEcho/Services/TranscriberPreference.swift
@@ -83,9 +83,11 @@ final class TranscriberPreference {
         self.liveKeyName = liveKey
         self.postRecordingKeyName = postRecordingKey
 
-        self.liveType = defaults.string(forKey: liveKey)
+        self.liveType =
+            defaults.string(forKey: liveKey)
             .flatMap(TranscriberType.init(rawValue:)) ?? .speechTranscriber
-        self.postRecordingType = defaults.string(forKey: postRecordingKey)
+        self.postRecordingType =
+            defaults.string(forKey: postRecordingKey)
             .flatMap(TranscriberType.init(rawValue:)) ?? .speechTranscriber
     }
 

--- a/MindEcho/MindEcho/Services/TranscriptionService.swift
+++ b/MindEcho/MindEcho/Services/TranscriptionService.swift
@@ -1,5 +1,5 @@
-import Foundation
 import AVFAudio
+import Foundation
 import Speech
 
 struct TranscriptionService {
@@ -12,15 +12,20 @@ struct TranscriptionService {
     ) async throws -> String {
         switch transcriberType {
         case .speechTranscriber:
-            try await transcribeWithSpeech(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
+            try await transcribeWithSpeech(
+                audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
         case .dictationTranscriber:
-            try await transcribeWithDictation(audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
+            try await transcribeWithDictation(
+                audioFileURL: audioFileURL, locale: locale, contextualStrings: contextualStrings)
         case .whisperAPI:
-            try await WhisperAPIService().transcribe(audioFileURL: audioFileURL, apiKey: openAIAPIKey, contextualStrings: contextualStrings)
+            try await WhisperAPIService().transcribe(
+                audioFileURL: audioFileURL, apiKey: openAIAPIKey, contextualStrings: contextualStrings)
         }
     }
 
-    private func transcribeWithSpeech(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws -> String {
+    private func transcribeWithSpeech(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws
+        -> String
+    {
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
 
         async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in
@@ -49,7 +54,9 @@ struct TranscriptionService {
         return resultText.trimmingCharacters(in: CharacterSet.whitespaces)
     }
 
-    private func transcribeWithDictation(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws -> String {
+    private func transcribeWithDictation(audioFileURL: URL, locale: Locale, contextualStrings: [String]) async throws
+        -> String
+    {
         let transcriber = DictationTranscriber(locale: locale, preset: .longDictation)
 
         async let transcriptionFuture: String = transcriber.results.reduce("") { partialResult, result in

--- a/MindEcho/MindEcho/Services/WhisperAPIService.swift
+++ b/MindEcho/MindEcho/Services/WhisperAPIService.swift
@@ -21,7 +21,7 @@ struct WhisperAPIService: Sendable {
         }
     }
 
-    private static let maxFileSize = 25 * 1024 * 1024 // 25MB
+    private static let maxFileSize = 25 * 1024 * 1024  // 25MB
     private static let endpoint = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
 
     func transcribe(audioFileURL: URL, apiKey: String, contextualStrings: [String] = []) async throws -> String {

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -42,8 +42,11 @@ class HomeViewModel {
     var summarizerType: SummarizerType = .onDevice
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
-        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
+    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = {
+        url, locale, contextualStrings, transcriberType, openAIAPIKey in
+        try await TranscriptionService().transcribe(
+            audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType,
+            openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
     var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
@@ -181,12 +184,14 @@ class HomeViewModel {
 
     func startTranscription() async {
         guard let fileName = lastRecordedFileName,
-              let recording = lastRecordedRecording else { return }
+            let recording = lastRecordedRecording
+        else { return }
         let url = FilePathManager.recordingsDirectory.appendingPathComponent(fileName)
         transcriptionState = .loading
         summaryState = .idle
         do {
-            let text = try await transcribe(url, Locale(identifier: "ja-JP"), vocabularyWords, postRecordingTranscriberType, openAIAPIKey)
+            let text = try await transcribe(
+                url, Locale(identifier: "ja-JP"), vocabularyWords, postRecordingTranscriberType, openAIAPIKey)
             if text.isEmpty {
                 transcriptionState = .failure("書き起こし結果が空でした。")
             } else {
@@ -357,7 +362,9 @@ class HomeViewModel {
             liveTranscriber.feedAudioBuffer(buffer, format: format)
         }
 
-        let stream = liveTranscriber.start(locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords, transcriberType: liveTranscriberType)
+        let stream = liveTranscriber.start(
+            locale: Locale(identifier: "ja-JP"), contextualStrings: vocabularyWords,
+            transcriberType: liveTranscriberType)
         liveTranscriptionTask = Task { @MainActor [weak self] in
             do {
                 for try await text in stream {

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -29,8 +29,11 @@ final class TranscriptionViewModel {
     var summarizerType: SummarizerType = .onDevice
 
     @ObservationIgnored
-    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = { url, locale, contextualStrings, transcriberType, openAIAPIKey in
-        try await TranscriptionService().transcribe(audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType, openAIAPIKey: openAIAPIKey)
+    var transcribe: (URL, Locale, [String], TranscriberType, String) async throws -> String = {
+        url, locale, contextualStrings, transcriberType, openAIAPIKey in
+        try await TranscriptionService().transcribe(
+            audioFileURL: url, locale: locale, contextualStrings: contextualStrings, transcriberType: transcriberType,
+            openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
     var checkAuthorization: () -> SFSpeechRecognizerAuthorizationStatus = {
@@ -86,7 +89,8 @@ final class TranscriptionViewModel {
             .appendingPathComponent(recording.audioFileName)
 
         do {
-            let text = try await transcribe(fileURL, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType, openAIAPIKey)
+            let text = try await transcribe(
+                fileURL, Locale(identifier: "ja-JP"), vocabularyWords, transcriberType, openAIAPIKey)
             if text.isEmpty {
                 state = .failure("書き起こし結果が空でした。")
             } else {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -22,12 +22,13 @@ struct HomeView: View {
         audioPlayer: any AudioPlaying = AudioPlayerService(),
         liveTranscriber: (any LiveTranscribing)? = nil
     ) {
-        _viewModel = State(initialValue: HomeViewModel(
-            modelContext: modelContext,
-            audioRecorder: audioRecorder,
-            audioPlayer: audioPlayer,
-            liveTranscriber: liveTranscriber
-        ))
+        _viewModel = State(
+            initialValue: HomeViewModel(
+                modelContext: modelContext,
+                audioRecorder: audioRecorder,
+                audioPlayer: audioPlayer,
+                liveTranscriber: liveTranscriber
+            ))
     }
 
     var body: some View {
@@ -76,10 +77,12 @@ struct HomeView: View {
                     }
                 }
             }
-            .sheet(isPresented: Binding(
-                get: { shareItems != nil },
-                set: { if !$0 { shareItems = nil } }
-            )) {
+            .sheet(
+                isPresented: Binding(
+                    get: { shareItems != nil },
+                    set: { if !$0 { shareItems = nil } }
+                )
+            ) {
                 if let items = shareItems {
                     ShareSheet(activityItems: items)
                 }
@@ -115,21 +118,36 @@ struct HomeView: View {
                 VocabularyView(store: vocabularyStore)
             }
             .sheet(isPresented: $showSettings) {
-                SettingsView(transcriberPreference: transcriberPreference, summarizerPreference: summarizerPreference, openAIAPIKeyStore: openAIAPIKeyStore, summaryPromptStore: summaryPromptStore)
+                SettingsView(
+                    transcriberPreference: transcriberPreference,
+                    summarizerPreference: summarizerPreference,
+                    openAIAPIKeyStore: openAIAPIKeyStore,
+                    summaryPromptStore: summaryPromptStore
+                )
             }
-            .sheet(isPresented: $isRecordingModalPresented, onDismiss: {
-                if viewModel.isRecording {
-                    viewModel.stopRecording()
+            .sheet(
+                isPresented: $isRecordingModalPresented,
+                onDismiss: {
+                    if viewModel.isRecording {
+                        viewModel.stopRecording()
+                    }
+                    viewModel.recordingTargetDate = nil
+                    viewModel.resetTranscriptionState()
+                    viewModel.fetchAllEntries()
                 }
-                viewModel.recordingTargetDate = nil
-                viewModel.resetTranscriptionState()
-                viewModel.fetchAllEntries()
-            }) {
+            ) {
                 RecordingModalView(viewModel: viewModel)
             }
             .sheet(item: $transcriptionTargetRecording) { recording in
-                TranscriptionView(recording: recording, vocabularyWords: vocabularyStore.words, transcriberType: transcriberPreference.postRecordingType, openAIAPIKey: openAIAPIKeyStore.apiKey, summaryInstruction: summaryPromptStore.instruction, summarizerType: summarizerPreference.type)
-                    .accessibilityIdentifier("home.transcriptionSheet")
+                TranscriptionView(
+                    recording: recording,
+                    vocabularyWords: vocabularyStore.words,
+                    transcriberType: transcriberPreference.postRecordingType,
+                    openAIAPIKey: openAIAPIKeyStore.apiKey,
+                    summaryInstruction: summaryPromptStore.instruction,
+                    summarizerType: summarizerPreference.type
+                )
+                .accessibilityIdentifier("home.transcriptionSheet")
             }
         }
     }
@@ -193,7 +211,8 @@ struct HomeView: View {
     @ViewBuilder
     private func recordingRow(_ recording: Recording, isToday: Bool, entry: JournalEntry? = nil) -> some View {
         let prefix = isToday ? "home" : "past"
-        let suffix = isToday
+        let suffix =
+            isToday
             ? "\(recording.sequenceNumber)"
             : "\(dateTag(entry!.date)).\(recording.sequenceNumber)"
         let isCurrentlyPlaying = viewModel.playingRecordingId == recording.id && viewModel.isPlaying

--- a/MindEcho/MindEchoTests/HomeViewModelTests.swift
+++ b/MindEcho/MindEchoTests/HomeViewModelTests.swift
@@ -1,13 +1,16 @@
-import Testing
 import Foundation
 import MindEchoAudio
 import MindEchoCore
 import SwiftData
+import Testing
+
 @testable import MindEcho
 
 @MainActor
 struct HomeViewModelTests {
-    private func makeViewModel() throws -> (HomeViewModel, MockAudioRecorderService, MockAudioPlayerService, ModelContainer) {
+    private func makeViewModel() throws -> (
+        HomeViewModel, MockAudioRecorderService, MockAudioPlayerService, ModelContainer
+    ) {
         let schema = Schema([JournalEntry.self, Recording.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
@@ -227,7 +230,9 @@ struct HomeViewModelTests {
     @Test func startTranscription_summarizationThrows_setsFailureState() async throws {
         let (vm, _, _, _container) = try makeViewModel()
         vm.transcribe = { _, _, _, _, _ in "書き起こしテスト結果" }
-        vm.summarize = { _, _, _, _ in throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"]) }
+        vm.summarize = { _, _, _, _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "テストエラー"])
+        }
         vm.isSummarizationAvailable = { _, _ in true }
         vm.startRecording()
         vm.stopRecording()
@@ -286,6 +291,6 @@ struct HomeViewModelTests {
 
         let recording = vm.todayEntry!.recordings.first!
         vm.deleteRecording(recording, from: vm.todayEntry!)
-        #expect(vm.todayEntry == nil) // Entry deleted since it had no more recordings
+        #expect(vm.todayEntry == nil)  // Entry deleted since it had no more recordings
     }
 }

--- a/MindEcho/MindEchoTests/SummarizationTests.swift
+++ b/MindEcho/MindEchoTests/SummarizationTests.swift
@@ -1,7 +1,8 @@
-import Testing
 import Foundation
-import Speech
 import MindEchoCore
+import Speech
+import Testing
+
 @testable import MindEcho
 
 @MainActor

--- a/MindEcho/MindEchoTests/SummaryPromptStoreTests.swift
+++ b/MindEcho/MindEchoTests/SummaryPromptStoreTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import MindEcho
 
 @MainActor

--- a/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
+++ b/MindEcho/MindEchoTests/TranscriberPreferenceTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import MindEcho
 
 @MainActor

--- a/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
+++ b/MindEcho/MindEchoTests/TranscriptionViewModelTests.swift
@@ -1,7 +1,8 @@
-import Testing
 import Foundation
 import MindEchoCore
 import Speech
+import Testing
+
 @testable import MindEcho
 
 @MainActor

--- a/MindEcho/MindEchoTests/VocabularyStoreTests.swift
+++ b/MindEcho/MindEchoTests/VocabularyStoreTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import MindEcho
 
 @MainActor

--- a/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/TranscriptionUITests.swift
@@ -6,7 +6,9 @@ final class TranscriptionUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization"]
+        app.launchArguments = [
+            "--uitesting", "--seed-today-with-recordings", "--mock-transcription", "--mock-summarization",
+        ]
     }
 
     // Helper: find the recording row regardless of its accessibility type.

--- a/Packages/MindEchoAudio/Package.swift
+++ b/Packages/MindEchoAudio/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MindEchoAudio",
     platforms: [.iOS(.v26)],
     products: [
-        .library(name: "MindEchoAudio", targets: ["MindEchoAudio"]),
+        .library(name: "MindEchoAudio", targets: ["MindEchoAudio"])
     ],
     targets: [
         .target(name: "MindEchoAudio", swiftSettings: [.swiftLanguageMode(.v5)]),

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioMerger.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioMerger.swift
@@ -57,10 +57,12 @@ public struct AudioMerger {
         for url in recordingURLs {
             let file = try AVAudioFile(forReading: url)
             let frameCount = AVAudioFrameCount(file.length)
-            guard let buffer = AVAudioPCMBuffer(
-                pcmFormat: file.processingFormat,
-                frameCapacity: frameCount
-            ) else {
+            guard
+                let buffer = AVAudioPCMBuffer(
+                    pcmFormat: file.processingFormat,
+                    frameCapacity: frameCount
+                )
+            else {
                 continue
             }
             try file.read(into: buffer)
@@ -97,10 +99,12 @@ public struct AudioMerger {
         }
         let ratio = format.sampleRate / buffer.format.sampleRate
         let outputFrameCount = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
-        guard let outputBuffer = AVAudioPCMBuffer(
-            pcmFormat: format,
-            frameCapacity: outputFrameCount
-        ) else {
+        guard
+            let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: outputFrameCount
+            )
+        else {
             return nil
         }
 

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/AudioRecorderService.swift
@@ -48,8 +48,9 @@ public class AudioRecorderService: AudioRecording {
 
         guard format.sampleRate > 0, format.channelCount > 0 else {
             try session.setActive(false)
-            throw NSError(domain: "AudioRecorderService", code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: "マイクが利用できません"])
+            throw NSError(
+                domain: "AudioRecorderService", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "マイクが利用できません"])
         }
 
         let settings: [String: Any] = [

--- a/Packages/MindEchoAudio/Sources/MindEchoAudio/TTSGenerator.swift
+++ b/Packages/MindEchoAudio/Sources/MindEchoAudio/TTSGenerator.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 
+// swift-format-ignore: AvoidRetroactiveConformances
 extension AVAudioPCMBuffer: @retroactive @unchecked Sendable {}
 
 public struct TTSGenerator {

--- a/Packages/MindEchoCore/Package.swift
+++ b/Packages/MindEchoCore/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MindEchoCore",
     platforms: [.iOS(.v26)],
     products: [
-        .library(name: "MindEchoCore", targets: ["MindEchoCore"]),
+        .library(name: "MindEchoCore", targets: ["MindEchoCore"])
     ],
     targets: [
         .target(name: "MindEchoCore"),

--- a/Packages/MindEchoCore/Sources/MindEchoCore/JournalEntry.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/JournalEntry.swift
@@ -18,8 +18,10 @@ public class JournalEntry {
         recordings.reduce(0) { $0 + $1.duration }
     }
 
-    public init(id: UUID = UUID(), date: Date, createdAt: Date = Date(), updatedAt: Date = Date(),
-         recordings: [Recording] = []) {
+    public init(
+        id: UUID = UUID(), date: Date, createdAt: Date = Date(), updatedAt: Date = Date(),
+        recordings: [Recording] = []
+    ) {
         self.id = id
         self.date = date
         self.createdAt = createdAt

--- a/Packages/MindEchoCore/Sources/MindEchoCore/Recording.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/Recording.swift
@@ -22,9 +22,11 @@ public class Recording {
         summary != nil
     }
 
-    public init(id: UUID = UUID(), sequenceNumber: Int, audioFileName: String,
-         duration: TimeInterval, recordedAt: Date = Date(), transcription: String? = nil,
-         summary: String? = nil) {
+    public init(
+        id: UUID = UUID(), sequenceNumber: Int, audioFileName: String,
+        duration: TimeInterval, recordedAt: Date = Date(), transcription: String? = nil,
+        summary: String? = nil
+    ) {
         self.id = id
         self.sequenceNumber = sequenceNumber
         self.audioFileName = audioFileName

--- a/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
+++ b/Packages/MindEchoCore/Tests/MindEchoCoreTests/DateHelperTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import MindEchoCore
 
 @MainActor
@@ -21,14 +22,14 @@ struct DateHelperTests {
         let cal = Calendar.current
         #expect(cal.component(.day, from: logical) == 7)
         #expect(cal.component(.month, from: logical) == 2)
-        #expect(cal.component(.hour, from: logical) == 12) // normalized to noon
+        #expect(cal.component(.hour, from: logical) == 12)  // normalized to noon
     }
 
     @Test func lateNightBeforeBoundary_returnsPreviousDay() {
         let date = makeDate(year: 2025, month: 2, day: 8, hour: 2, minute: 30)
         let logical = DateHelper.logicalDate(for: date)
         let cal = Calendar.current
-        #expect(cal.component(.day, from: logical) == 7) // Previous day
+        #expect(cal.component(.day, from: logical) == 7)  // Previous day
         #expect(cal.component(.month, from: logical) == 2)
     }
 
@@ -36,14 +37,14 @@ struct DateHelperTests {
         let date = makeDate(year: 2025, month: 2, day: 8, hour: 3, minute: 0)
         let logical = DateHelper.logicalDate(for: date)
         let cal = Calendar.current
-        #expect(cal.component(.day, from: logical) == 8) // Current day (3AM is boundary)
+        #expect(cal.component(.day, from: logical) == 8)  // Current day (3AM is boundary)
     }
 
     @Test func justBeforeBoundary_returnsPreviousDay() {
         let date = makeDate(year: 2025, month: 2, day: 8, hour: 2, minute: 59)
         let logical = DateHelper.logicalDate(for: date)
         let cal = Calendar.current
-        #expect(cal.component(.day, from: logical) == 7) // Previous day
+        #expect(cal.component(.day, from: logical) == 7)  // Previous day
     }
 
     @Test func midnight_returnsPreviousDay() {

--- a/Packages/MindEchoCore/Tests/MindEchoCoreTests/FilePathManagerTests.swift
+++ b/Packages/MindEchoCore/Tests/MindEchoCoreTests/FilePathManagerTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import MindEchoCore
 
 @MainActor


### PR DESCRIPTION
## Summary

- Apple 公式の `swift-format` を導入し、全 Swift ソースコードにフォーマットを適用
- `.swift-format` 設定ファイルをプロジェクトルートに追加（4 spaces インデント、120 文字行長）
- Git pre-commit hook でステージされた `.swift` ファイルのリントを自動実行
- CLAUDE.md の Coding Guidelines / File Structure セクションを更新

Closes #105

## Test plan

- [x] `xcrun swift-format lint --recursive` で警告ゼロを確認
- [x] `xcodebuild build` が成功することを確認
- [x] 全ユニットテスト (53件) がパスすることを確認
- [x] pre-commit hook がコミット時に正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)