### PR TITLE
ci: ビルド前に swift-format lint ジョブを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,14 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
       - name: Run swift-format lint
         run: |
-          xcrun swift-format lint \
+          swift-format lint \
             --recursive \
             --strict \
             MindEcho/MindEcho \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,14 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
       - name: Run swift-format lint
         run: |
-          swift-format lint \
+          xcrun swift-format lint \
             --recursive \
             --strict \
             MindEcho/MindEcho \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,24 @@ env:
   WORKSPACE: MindEcho.xcworkspace
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: macos-26
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run swift-format lint
+        run: |
+          xcrun swift-format lint \
+            --recursive \
+            --configuration .swift-format \
+            MindEcho/MindEcho \
+            Packages/
+
   build:
     name: Build
+    needs: lint
     runs-on: macos-26
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           xcrun swift-format lint \
             --recursive \
+            --strict \
             --configuration .swift-format \
             MindEcho/MindEcho \
             Packages/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
           xcrun swift-format lint \
             --recursive \
             --strict \
-            --configuration .swift-format \
             MindEcho/MindEcho \
             Packages/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ xcodebuild test \
 
 Apple 公式の [swift-format](https://github.com/swiftlang/swift-format) を使用してコードスタイルを統一しています。設定はプロジェクトルートの `.swift-format` を参照。
 
-- コミット前にフォーマットを適用すること: `xcrun swift-format format --in-place --recursive --configuration .swift-format <対象ディレクトリ>`
+- コミット前にフォーマットを適用すること: `xcrun swift-format format --in-place --recursive <対象ディレクトリ>`
 
 ### Swift Concurrency
 

--- a/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
+++ b/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
@@ -51,31 +51,33 @@ struct OpenAISummarizationService: Sendable {
         if httpResponse.statusCode != 200 {
             // OpenAI エラーレスポンスからユーザー向けメッセージを抽出
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let errorDict = json["error"] as? [String: Any],
-               let message = errorDict["message"] as? String,
-               !message.isEmpty {
+                let errorDict = json["error"] as? [String: Any],
+                let message = errorDict["message"] as? String,
+                !message.isEmpty
+            {
                 throw SummarizationError.apiError(message)
             }
 
             // ステータスコードに応じた定型文にフォールバック
-            let userMessage: String = switch httpResponse.statusCode {
-            case 401:
-                "API キーが無効か、認証に失敗しました。設定を確認してください。"
-            case 429:
-                "リクエストが多すぎます。しばらく時間をおいてから再試行してください。"
-            case 500...599:
-                "OpenAI API 側でエラーが発生しました。時間をおいて再試行してください。"
-            default:
-                "HTTP \(httpResponse.statusCode) エラーが発生しました。"
-            }
+            let userMessage: String =
+                switch httpResponse.statusCode {
+                case 401:
+                    "API キーが無効か、認証に失敗しました。設定を確認してください。"
+                case 429:
+                    "リクエストが多すぎます。しばらく時間をおいてから再試行してください。"
+                case 500...599:
+                    "OpenAI API 側でエラーが発生しました。時間をおいて再試行してください。"
+                default:
+                    "HTTP \(httpResponse.statusCode) エラーが発生しました。"
+                }
             throw SummarizationError.apiError(userMessage)
         }
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let firstChoice = choices.first,
-              let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String
+            let choices = json["choices"] as? [[String: Any]],
+            let firstChoice = choices.first,
+            let message = firstChoice["message"] as? [String: Any],
+            let content = message["content"] as? String
         else {
             throw SummarizationError.invalidResponse
         }

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -18,7 +18,9 @@ struct SummarizationService {
 
     // MARK: - Dispatch (共通エントリポイント)
 
-    static func summarize(text: String, instruction: String, type: SummarizerType, apiKey: String) async throws -> String {
+    static func summarize(
+        text: String, instruction: String, type: SummarizerType, apiKey: String
+    ) async throws -> String {
         switch type {
         case .onDevice:
             try await SummarizationService().summarize(text: text, instruction: instruction)

--- a/MindEcho/MindEcho/Services/SummarizerPreference.swift
+++ b/MindEcho/MindEcho/Services/SummarizerPreference.swift
@@ -38,7 +38,8 @@ final class SummarizerPreference {
     init(defaults: UserDefaults = .standard, key: String = defaultKey) {
         self.defaults = defaults
         self.keyName = key
-        self.type = defaults.string(forKey: key)
+        self.type =
+            defaults.string(forKey: key)
             .flatMap(SummarizerType.init(rawValue:)) ?? .onDevice
     }
 }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -49,7 +49,8 @@ class HomeViewModel {
             openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
-    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+    var summarize: (String, String, SummarizerType, String) async throws -> String = {
+        text, instruction, type, apiKey in
         try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
     }
     @ObservationIgnored

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -44,7 +44,8 @@ final class TranscriptionViewModel {
         SFSpeechRecognizer.requestAuthorization($0)
     }
     @ObservationIgnored
-    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+    var summarize: (String, String, SummarizerType, String) async throws -> String = {
+        text, instruction, type, apiKey in
         try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
     }
     @ObservationIgnored


### PR DESCRIPTION
## Summary

- `lint` ジョブを追加し、`build` の前に swift-format によるスタイルチェックを実行するよう変更
- lint が失敗した場合はビルドに進まない
- 実行順序: `lint → build → unit-tests / ui-tests`

## Test plan

- [ ] ワークフローが `lint → build → tests` の順で実行されることを確認
- [ ] lint エラーがある場合にビルドがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)