### PR TITLE
Add PDF transcript sharing

### DIFF
--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -1,8 +1,8 @@
 import AVFoundation
+import CoreText
 import Foundation
 import MindEchoAudio
 import MindEchoCore
-import CoreText
 import UIKit
 
 struct ExportServiceImpl: Exporting {

--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -2,6 +2,8 @@ import AVFoundation
 import Foundation
 import MindEchoAudio
 import MindEchoCore
+import CoreText
+import UIKit
 
 struct ExportServiceImpl: Exporting {
     func exportMergedAudio(entry: JournalEntry, to directory: URL) async throws -> URL {
@@ -39,11 +41,7 @@ struct ExportServiceImpl: Exporting {
     func exportCombinedTranscript(entry: JournalEntry, to directory: URL) throws -> URL {
         try FilePathManager.ensureDirectoryExists(directory)
 
-        // Build transcript text with date header
-        let dateHeader = DateHelper.displayString(for: entry.date)
-        let transcriptions = entry.sortedRecordings.compactMap(\.transcription)
-        let body = transcriptions.joined(separator: "\n\n")
-        let content = dateHeader + "\n\n" + body
+        let content = transcriptContent(for: entry)
 
         // Write to export directory
         let formatter = DateFormatter()
@@ -55,5 +53,68 @@ struct ExportServiceImpl: Exporting {
         try content.write(to: exportURL, atomically: true, encoding: .utf8)
 
         return exportURL
+    }
+
+    func exportTranscriptPDF(entry: JournalEntry, to directory: URL) throws -> URL {
+        try FilePathManager.ensureDirectoryExists(directory)
+
+        let content = transcriptContent(for: entry)
+        let exportURL = directory.appendingPathComponent(
+            FilePathManager.exportTranscriptPDFURL(for: entry.date).lastPathComponent
+        )
+
+        let pageRect = CGRect(x: 0, y: 0, width: 595, height: 842)
+        let margin: CGFloat = 40
+        let textRect = pageRect.insetBy(dx: margin, dy: margin)
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.lineSpacing = 4
+
+        let bodyFont = UIFont.systemFont(ofSize: 14)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: bodyFont,
+            .foregroundColor: UIColor.black,
+            .paragraphStyle: paragraphStyle,
+        ]
+        let attributedText = NSAttributedString(string: content, attributes: attributes)
+        let framesetter = CTFramesetterCreateWithAttributedString(attributedText)
+
+        try renderer.writePDF(to: exportURL) { context in
+            var currentRange = CFRange(location: 0, length: 0)
+
+            while currentRange.location < attributedText.length {
+                context.beginPage()
+
+                let path = CGPath(rect: textRect, transform: nil)
+                let frame = CTFramesetterCreateFrame(
+                    framesetter,
+                    currentRange,
+                    path,
+                    nil
+                )
+
+                let visibleRange = CTFrameGetVisibleStringRange(frame)
+                let cgContext = context.cgContext
+                cgContext.saveGState()
+                cgContext.textMatrix = .identity
+                cgContext.translateBy(x: 0, y: pageRect.height)
+                cgContext.scaleBy(x: 1, y: -1)
+                CTFrameDraw(frame, cgContext)
+                cgContext.restoreGState()
+
+                currentRange.location += visibleRange.length
+            }
+        }
+
+        return exportURL
+    }
+
+    private func transcriptContent(for entry: JournalEntry) -> String {
+        let dateHeader = DateHelper.displayString(for: entry.date)
+        let transcriptions = entry.sortedRecordings.compactMap(\.transcription)
+        let body = transcriptions.joined(separator: "\n\n")
+        return dateHeader + "\n\n" + body
     }
 }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -321,6 +321,11 @@ class HomeViewModel {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    func exportTranscriptPDFForSharing(entry: JournalEntry) throws -> URL {
+        let exportDir = FilePathManager.exportsDirectory
+        return try exportService.exportTranscriptPDF(entry: entry, to: exportDir)
+    }
+
     // MARK: - Private
 
     private func getOrCreateEntry(for logicalDate: Date) -> JournalEntry {

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -343,6 +343,13 @@ struct HomeView: View {
                 Label("テキストを共有", systemImage: "doc.text")
             }
             .accessibilityIdentifier("\(prefix).shareTranscriptButton\(suffix)")
+
+            Button {
+                exportAndShareTranscriptPDF(entry: entry)
+            } label: {
+                Label("PDFを共有", systemImage: "doc.richtext")
+            }
+            .accessibilityIdentifier("\(prefix).shareTranscriptPDFButton\(suffix)")
         } label: {
             Image(systemName: "square.and.arrow.up")
         }
@@ -367,6 +374,17 @@ struct HomeView: View {
             do {
                 let text = try viewModel.exportTranscriptForSharing(entry: entry)
                 shareItems = [text]
+            } catch {
+                // Handle error silently for now
+            }
+        }
+    }
+
+    private func exportAndShareTranscriptPDF(entry: JournalEntry) {
+        Task { @MainActor in
+            do {
+                let url = try viewModel.exportTranscriptPDFForSharing(entry: entry)
+                shareItems = [url]
             } catch {
                 // Handle error silently for now
             }

--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -70,6 +70,24 @@ final class EntryDetailUITests: XCTestCase {
     }
 
     @MainActor
+    func testSharePDFButton_presentsActivitySheet() throws {
+        app.launch()
+
+        let shareBtn = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier == 'home.shareButton'")
+        ).firstMatch
+        XCTAssertTrue(shareBtn.waitForExistence(timeout: 5))
+        shareBtn.tap()
+
+        let pdfBtn = app.buttons["PDFを共有"]
+        XCTAssertTrue(pdfBtn.waitForExistence(timeout: 5))
+        pdfBtn.tap()
+
+        let activityList = app.otherElements["ActivityListView"]
+        XCTAssertTrue(activityList.waitForExistence(timeout: 15))
+    }
+
+    @MainActor
     func testMenuDelete_removesRecording() throws {
         app.launch()
 

--- a/Packages/MindEchoCore/Sources/MindEchoCore/Exporting.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/Exporting.swift
@@ -3,4 +3,5 @@ import Foundation
 public protocol Exporting {
     func exportMergedAudio(entry: JournalEntry, to directory: URL) async throws -> URL
     func exportCombinedTranscript(entry: JournalEntry, to directory: URL) throws -> URL
+    func exportTranscriptPDF(entry: JournalEntry, to directory: URL) throws -> URL
 }

--- a/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
@@ -52,6 +52,15 @@ public enum FilePathManager {
         return exportsDirectory.appendingPathComponent(fileName)
     }
 
+    /// Returns the export transcript PDF URL for a given logical date
+    public static func exportTranscriptPDFURL(for logicalDate: Date) -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let fileName = formatter.string(from: logicalDate) + "_transcript.pdf"
+        return exportsDirectory.appendingPathComponent(fileName)
+    }
+
     /// Ensures a directory exists, creating it if necessary
     public static func ensureDirectoryExists(_ url: URL) throws {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
## 概要

共有機能に、既存のテキスト共有と同じ内容を PDF ファイルとして書き出して共有できる導線を追加しました。NotebookLM 取り込み時に日付入りファイル名で扱えるようにするのが目的です。

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [x] テストの追加・修正
- [ ] ビルド・CI設定の変更
- [ ] その他

## 変更内容

- 書き起こしテキストを PDF として出力する `exportTranscriptPDF` を追加
- `yyyyMMdd_transcript.pdf` 形式の日付入りファイル名で `Documents/Exports/` 配下へ出力
- 共有メニューに `PDFを共有` を追加
- PDF 共有フローの UI テストを追加

## 影響範囲

- 対象画面: ホーム画面の共有メニュー
- 対象機能: 書き起こし共有、エクスポート、NotebookLM 向け共有フロー

## スクリーンショット / 動画

| 変更前 | 変更後 |
|--------|--------|
| なし | なし |

## テスト

- [ ] ユニットテストを追加・更新した
- [x] UIテストを追加・更新した
- [x] シミュレータで動作確認した
- [ ] 実機で動作確認した

## チェックリスト

- [x] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [x] 不要なデバッグコード・print文を削除した
- [x] 既存の機能にデグレがないことを確認した

## 関連Issue

なし

## レビュアーへの補足

既存の `テキストを共有` は維持しつつ、NotebookLM 取り込み用の回避策として `PDFを共有` を追加しています。TestFlight 配信は GitHub Actions で実施済みです。
