### PR TITLE
Add Periphery check to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,14 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
       - name: Run swift-format lint
         run: |
-          xcrun swift-format lint \
+          swift-format lint \
             --recursive \
             --strict \
             MindEcho/MindEcho \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,14 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
       - name: Run swift-format lint
         run: |
-          swift-format lint \
+          xcrun swift-format lint \
             --recursive \
             --strict \
             MindEcho/MindEcho \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,24 @@ env:
   WORKSPACE: MindEcho.xcworkspace
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: macos-26
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run swift-format lint
+        run: |
+          xcrun swift-format lint \
+            --recursive \
+            --configuration .swift-format \
+            MindEcho/MindEcho \
+            Packages/
+
   build:
     name: Build
+    needs: lint
     runs-on: macos-26
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,33 @@ jobs:
             MindEcho/MindEcho \
             Packages/
 
+  periphery:
+    name: Periphery
+    needs: lint
+    runs-on: macos-26
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Mint
+        run: brew install mint
+
+      - name: Install Mint dependencies
+        run: mint bootstrap
+
+      - name: Run periphery scan
+        run: |
+          mint run periphery scan \
+            --project $WORKSPACE \
+            --schemes MindEcho \
+            --format github-actions \
+            --relative-results
+
   build:
     name: Build
-    needs: lint
+    needs:
+      - lint
+      - periphery
     runs-on: macos-26
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           xcrun swift-format lint \
             --recursive \
+            --strict \
             --configuration .swift-format \
             MindEcho/MindEcho \
             Packages/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
           xcrun swift-format lint \
             --recursive \
             --strict \
-            --configuration .swift-format \
             MindEcho/MindEcho \
             Packages/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ xcodebuild test \
 
 Apple 公式の [swift-format](https://github.com/swiftlang/swift-format) を使用してコードスタイルを統一しています。設定はプロジェクトルートの `.swift-format` を参照。
 
-- コミット前にフォーマットを適用すること: `xcrun swift-format format --in-place --recursive --configuration .swift-format <対象ディレクトリ>`
+- コミット前にフォーマットを適用すること: `xcrun swift-format format --in-place --recursive <対象ディレクトリ>`
 
 ### Swift Concurrency
 

--- a/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
+++ b/MindEcho/MindEcho/Services/OpenAISummarizationService.swift
@@ -51,31 +51,33 @@ struct OpenAISummarizationService: Sendable {
         if httpResponse.statusCode != 200 {
             // OpenAI エラーレスポンスからユーザー向けメッセージを抽出
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let errorDict = json["error"] as? [String: Any],
-               let message = errorDict["message"] as? String,
-               !message.isEmpty {
+                let errorDict = json["error"] as? [String: Any],
+                let message = errorDict["message"] as? String,
+                !message.isEmpty
+            {
                 throw SummarizationError.apiError(message)
             }
 
             // ステータスコードに応じた定型文にフォールバック
-            let userMessage: String = switch httpResponse.statusCode {
-            case 401:
-                "API キーが無効か、認証に失敗しました。設定を確認してください。"
-            case 429:
-                "リクエストが多すぎます。しばらく時間をおいてから再試行してください。"
-            case 500...599:
-                "OpenAI API 側でエラーが発生しました。時間をおいて再試行してください。"
-            default:
-                "HTTP \(httpResponse.statusCode) エラーが発生しました。"
-            }
+            let userMessage: String =
+                switch httpResponse.statusCode {
+                case 401:
+                    "API キーが無効か、認証に失敗しました。設定を確認してください。"
+                case 429:
+                    "リクエストが多すぎます。しばらく時間をおいてから再試行してください。"
+                case 500...599:
+                    "OpenAI API 側でエラーが発生しました。時間をおいて再試行してください。"
+                default:
+                    "HTTP \(httpResponse.statusCode) エラーが発生しました。"
+                }
             throw SummarizationError.apiError(userMessage)
         }
 
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let firstChoice = choices.first,
-              let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String
+            let choices = json["choices"] as? [[String: Any]],
+            let firstChoice = choices.first,
+            let message = firstChoice["message"] as? [String: Any],
+            let content = message["content"] as? String
         else {
             throw SummarizationError.invalidResponse
         }

--- a/MindEcho/MindEcho/Services/SummarizationService.swift
+++ b/MindEcho/MindEcho/Services/SummarizationService.swift
@@ -18,7 +18,9 @@ struct SummarizationService {
 
     // MARK: - Dispatch (共通エントリポイント)
 
-    static func summarize(text: String, instruction: String, type: SummarizerType, apiKey: String) async throws -> String {
+    static func summarize(
+        text: String, instruction: String, type: SummarizerType, apiKey: String
+    ) async throws -> String {
         switch type {
         case .onDevice:
             try await SummarizationService().summarize(text: text, instruction: instruction)

--- a/MindEcho/MindEcho/Services/SummarizerPreference.swift
+++ b/MindEcho/MindEcho/Services/SummarizerPreference.swift
@@ -38,7 +38,8 @@ final class SummarizerPreference {
     init(defaults: UserDefaults = .standard, key: String = defaultKey) {
         self.defaults = defaults
         self.keyName = key
-        self.type = defaults.string(forKey: key)
+        self.type =
+            defaults.string(forKey: key)
             .flatMap(SummarizerType.init(rawValue:)) ?? .onDevice
     }
 }

--- a/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/HomeViewModel.swift
@@ -49,7 +49,8 @@ class HomeViewModel {
             openAIAPIKey: openAIAPIKey)
     }
     @ObservationIgnored
-    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+    var summarize: (String, String, SummarizerType, String) async throws -> String = {
+        text, instruction, type, apiKey in
         try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
     }
     @ObservationIgnored

--- a/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/TranscriptionViewModel.swift
@@ -44,7 +44,8 @@ final class TranscriptionViewModel {
         SFSpeechRecognizer.requestAuthorization($0)
     }
     @ObservationIgnored
-    var summarize: (String, String, SummarizerType, String) async throws -> String = { text, instruction, type, apiKey in
+    var summarize: (String, String, SummarizerType, String) async throws -> String = {
+        text, instruction, type, apiKey in
         try await SummarizationService.summarize(text: text, instruction: instruction, type: type, apiKey: apiKey)
     }
     @ObservationIgnored

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,1 @@
+peripheryapp/periphery@3.6.0


### PR DESCRIPTION
## 概要

`test.yml` に Periphery のチェックを追加し、`lint` の後に実行されるようにしました。Periphery は `Mintfile` でバージョン固定し、GitHub Actions 上でも Mint 経由で実行します。

## 変更の種類

- [x] ビルド・CI設定の変更
- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他

## 変更内容

- `Mintfile` を追加し、`peripheryapp/periphery@3.6.0` を固定
- `test.yml` に `Periphery` ジョブを追加
- `lint` 成功後に `mint bootstrap` と `mint run periphery scan --project MindEcho.xcworkspace --schemes MindEcho --format github-actions --relative-results` を実行
- `build` ジョブが `lint` と `periphery` の両方に依存するよう変更

## 影響範囲

- 対象画面: なし
- 対象機能: GitHub Actions のテストワークフロー

## スクリーンショット / 動画

| 変更前 | 変更後 |
|--------|--------|
| なし | なし |

## テスト

- [ ] ユニットテストを追加・更新した
- [ ] UIテストを追加・更新した
- [ ] シミュレータで動作確認した
- [ ] 実機で動作確認した

補足: ローカルで `mint run periphery scan --project MindEcho.xcworkspace --schemes MindEcho --format github-actions --relative-results` を実行し、スキャンが完走して既存の unused warning が報告されることを確認しています。

## チェックリスト

- [ ] コードがビルドできることを確認した
- [ ] SwiftLint等の警告を解消した
- [x] 不要なデバッグコード・print文を削除した
- [ ] 既存の機能にデグレがないことを確認した

## 関連Issue

なし

## レビュアーへの補足

Periphery の結果は現状 warning のみで、CI を落とさない設定です。既存コードベースに unused 指摘が残っているため、まずは可視化だけを入れています。