### PR TITLE
feat: 月間共有機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ MindEchoApp (App Target)
 
 | モジュール | 責務 | 主な型 |
 |-----------|------|--------|
-| **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting` |
+| **MindEchoCore** | ドメインモデル, 日付ロジック, ファイル管理, エクスポート protocol, 月間共有形式 | `JournalEntry`, `Recording`, `DateHelper`, `FilePathManager`, `Exporting`, `MonthlyShareFormat` |
 | **MindEchoAudio** | 録音・再生・音声結合・TTS 生成 | `AudioRecorderService`, `AudioPlayerService`, `AudioMerger`, `TTSGenerator` |
-| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, SummaryPromptStore, WhisperAPIService, SummarizerPreference, OpenAISummarizationService, Mocks | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `SummarizationService`, `OpenAISummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `SummarizerPreference`, `SummarizerType`, `OpenAIAPIKeyStore`, `SummaryPromptStore`, `WhisperAPIService`, `VocabularyView` 等 |
+| **MindEchoApp** | Views, ViewModels, ExportService 実装, SummarizationService, VocabularyStore, TranscriberPreference, SummaryPromptStore, WhisperAPIService, SummarizerPreference, OpenAISummarizationService, Mocks, 月間共有 | `HomeView`, `HomeViewModel`, `RecordingModalView`, `TranscriptionView`, `SettingsView`, `ExportServiceImpl`, `PDFExportService`, `SummarizationService`, `OpenAISummarizationService`, `VocabularyStore`, `TranscriberPreference`, `TranscriberType`, `SummarizerPreference`, `SummarizerType`, `OpenAIAPIKeyStore`, `SummaryPromptStore`, `WhisperAPIService`, `VocabularyView`, `MonthlyShareView`, `MonthlyShareViewModel` 等 |
 
 ### Design Principles
 

--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -60,6 +60,9 @@ struct MindEchoApp: App {
             if args.contains("--seed-today-with-recordings") {
                 Self.seedTodayWithRecordings(context: context)
             }
+            if args.contains("--seed-multi-month-history") {
+                Self.seedMultiMonthHistory(context: context)
+            }
         }
     }
 
@@ -120,6 +123,41 @@ struct MindEchoApp: App {
             entry.recordings.append(recording)
         }
         context.insert(entry)
+    }
+
+    /// 複数月にまたがるサンプルデータを生成する（月間共有UIテスト用）
+    @MainActor
+    private static func seedMultiMonthHistory(context: ModelContext) {
+        let calendar = Calendar.current
+        // 当月・先月・2ヶ月前それぞれに2〜3件のエントリを作成
+        let monthOffsets: [(monthOffset: Int, dayOffsets: [Int])] = [
+            (monthOffset: 0, dayOffsets: [1, 5]),
+            (monthOffset: -1, dayOffsets: [3, 10, 20]),
+            (monthOffset: -2, dayOffsets: [2, 15]),
+        ]
+        for (monthOffset, dayOffsets) in monthOffsets {
+            for dayOffset in dayOffsets {
+                guard
+                    let baseDate = calendar.date(
+                        byAdding: .month, value: monthOffset, to: Date()),
+                    let targetDate = calendar.date(
+                        byAdding: .day, value: -dayOffset, to: baseDate)
+                else { continue }
+
+                let logicalDate = DateHelper.logicalDate(for: targetDate)
+                let entry = JournalEntry(date: logicalDate)
+                let fileName = "multi_\(abs(monthOffset))m_\(dayOffset)d.m4a"
+                createSilentAudioFile(named: fileName, duration: 5)
+                let recording = Recording(
+                    sequenceNumber: 1,
+                    audioFileName: fileName,
+                    duration: TimeInterval(30 * dayOffset)
+                )
+                recording.transcription = "サンプル書き起こし（\(abs(monthOffset))ヶ月前・\(dayOffset)日前）"
+                entry.recordings.append(recording)
+                context.insert(entry)
+            }
+        }
     }
 
     /// Creates a silent audio file in the recordings directory using AVAudioFile.

--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -36,6 +36,19 @@ struct ExportServiceImpl: Exporting {
         return exportURL
     }
 
+    func exportDailyPDF(entry: JournalEntry, to directory: URL) throws -> URL {
+        try FilePathManager.ensureDirectoryExists(directory)
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let dateStr = formatter.string(from: entry.date)
+
+        let exportURL = directory.appendingPathComponent("\(dateStr)_journal.pdf")
+        try PDFExportService.generateDailyPDF(entry: entry, outputURL: exportURL)
+        return exportURL
+    }
+
     func exportCombinedTranscript(entry: JournalEntry, to directory: URL) throws -> URL {
         try FilePathManager.ensureDirectoryExists(directory)
 

--- a/MindEcho/MindEcho/Services/PDFExportService.swift
+++ b/MindEcho/MindEcho/Services/PDFExportService.swift
@@ -1,0 +1,162 @@
+import MindEchoCore
+import UIKit
+
+/// 1日分のジャーナルエントリを PDF ファイルとして生成するサービス
+struct PDFExportService {
+    private static let pageWidth: CGFloat = 595.2  // A4 width in points
+    private static let pageHeight: CGFloat = 841.8  // A4 height in points
+    private static let margin: CGFloat = 36.0
+    private static let bodyWidth: CGFloat = pageWidth - margin * 2
+
+    /// 1日分のエントリを PDF 化して outputURL に書き出す
+    static func generateDailyPDF(entry: JournalEntry, outputURL: URL) throws {
+        let renderer = UIGraphicsPDFRenderer(
+            bounds: CGRect(x: 0, y: 0, width: pageWidth, height: pageHeight)
+        )
+
+        let data = renderer.pdfData { context in
+            context.beginPage()
+            var y: CGFloat = margin
+
+            // 日付ヘッダー
+            let dateString = DateHelper.displayString(for: entry.date)
+            y = drawText(
+                dateString,
+                at: CGPoint(x: margin, y: y),
+                font: .boldSystemFont(ofSize: 18),
+                color: .label,
+                maxWidth: bodyWidth,
+                context: context
+            )
+            y += 12
+
+            // 区切り線
+            let linePath = UIBezierPath()
+            linePath.move(to: CGPoint(x: margin, y: y))
+            linePath.addLine(to: CGPoint(x: pageWidth - margin, y: y))
+            UIColor.separator.setStroke()
+            linePath.lineWidth = 0.5
+            linePath.stroke()
+            y += 12
+
+            for recording in entry.sortedRecordings {
+                guard let transcription = recording.transcription, !transcription.isEmpty else { continue }
+
+                // 録音メタデータのサブヘッダー
+                let timeFormatter = DateFormatter()
+                timeFormatter.dateFormat = "HH:mm"
+                let timeStr = timeFormatter.string(from: recording.recordedAt)
+
+                let minutes = Int(recording.duration) / 60
+                let seconds = Int(recording.duration) % 60
+                let durationStr = String(format: "%d:%02d", minutes, seconds)
+
+                let subheader = "#\(recording.sequenceNumber)  \(timeStr)  (\(durationStr))"
+
+                // ページ終端チェック（サブヘッダー + 最低1行の本文分の余白）
+                if y + 60 > pageHeight - margin {
+                    context.beginPage()
+                    y = margin
+                }
+
+                y = drawText(
+                    subheader,
+                    at: CGPoint(x: margin, y: y),
+                    font: .boldSystemFont(ofSize: 13),
+                    color: .secondaryLabel,
+                    maxWidth: bodyWidth,
+                    context: context
+                )
+                y += 6
+
+                // 書き起こし本文
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.lineHeightMultiple = 1.4
+                let bodyAttributes: [NSAttributedString.Key: Any] = [
+                    .font: UIFont.systemFont(ofSize: 14),
+                    .foregroundColor: UIColor.label,
+                    .paragraphStyle: paragraphStyle,
+                ]
+                let attributedBody = NSAttributedString(string: transcription, attributes: bodyAttributes)
+
+                let textStorage = NSTextStorage(attributedString: attributedBody)
+                let layoutManager = NSLayoutManager()
+                textStorage.addLayoutManager(layoutManager)
+
+                var charIndex = 0
+                let totalChars = attributedBody.length
+
+                while charIndex < totalChars {
+                    let remainingHeight = pageHeight - margin - y
+                    let textContainer = NSTextContainer(
+                        size: CGSize(width: bodyWidth, height: remainingHeight)
+                    )
+                    textContainer.lineFragmentPadding = 0
+                    layoutManager.addTextContainer(textContainer)
+
+                    layoutManager.ensureLayout(for: textContainer)
+                    let range = layoutManager.glyphRange(for: textContainer)
+                    let usedRect = layoutManager.usedRect(for: textContainer)
+
+                    if range.length == 0 {
+                        // テキストがこのページに入りきらない場合は改ページ
+                        context.beginPage()
+                        y = margin
+                        // 新しいページで再試行するため textContainer を再作成
+                        layoutManager.removeTextContainer(at: layoutManager.textContainers.count - 1)
+                        continue
+                    }
+
+                    // テキストを描画
+                    let drawRect = CGRect(x: margin, y: y, width: bodyWidth, height: usedRect.height)
+                    layoutManager.drawBackground(
+                        forGlyphRange: range, at: CGPoint(x: margin, y: y))
+                    layoutManager.drawGlyphs(forGlyphRange: range, at: CGPoint(x: margin, y: y))
+
+                    y += drawRect.height
+                    charIndex += range.length
+
+                    if charIndex < totalChars {
+                        // まだ残りがある → 改ページ
+                        context.beginPage()
+                        y = margin
+                    }
+                }
+
+                y += 16  // 録音間の余白
+            }
+        }
+
+        try data.write(to: outputURL)
+    }
+
+    // MARK: - Private Helpers
+
+    /// テキストを指定位置に描画し、描画後の y 座標を返す
+    @discardableResult
+    private static func drawText(
+        _ text: String,
+        at point: CGPoint,
+        font: UIFont,
+        color: UIColor,
+        maxWidth: CGFloat,
+        context: UIGraphicsPDFRendererContext
+    ) -> CGFloat {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color,
+        ]
+        let rect = CGRect(x: point.x, y: point.y, width: maxWidth, height: .greatestFiniteMagnitude)
+        let boundingRect = (text as NSString).boundingRect(
+            with: rect.size, options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attributes, context: nil
+        )
+        (text as NSString).draw(
+            with: CGRect(x: point.x, y: point.y, width: maxWidth, height: boundingRect.height),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attributes,
+            context: nil
+        )
+        return point.y + boundingRect.height
+    }
+}

--- a/MindEcho/MindEcho/ViewModels/MonthlyShareViewModel.swift
+++ b/MindEcho/MindEcho/ViewModels/MonthlyShareViewModel.swift
@@ -1,0 +1,173 @@
+import Foundation
+import MindEchoCore
+import Observation
+import SwiftData
+
+@Observable
+@MainActor
+class MonthlyShareViewModel {
+    enum ExportState: Equatable {
+        case idle
+        case exporting(current: Int, total: Int)
+        case done([URL])
+        case failure(String)
+    }
+
+    struct AvailableMonth: Identifiable, Equatable {
+        let year: Int
+        let month: Int
+        let entryCount: Int
+        let recordingCount: Int
+
+        var id: String { String(format: "%04d%02d", year, month) }
+
+        var displayString: String {
+            // "2026年3月（5件）" のような文字列を表示用に構築
+            // DateHelper.monthDisplayString を利用するため Date に変換
+            var components = DateComponents()
+            components.year = year
+            components.month = month
+            components.day = 15  // 月の中頃を指定（正午換算はしない）
+            let date = Calendar.current.date(from: components) ?? Date()
+            let monthStr = DateHelper.monthDisplayString(for: date)
+            return "\(monthStr)（\(entryCount)件）"
+        }
+    }
+
+    var availableMonths: [AvailableMonth] = []
+    var selectedMonth: AvailableMonth?
+    var selectedFormat: MonthlyShareFormat = .pdf
+    var exportState: ExportState = .idle
+
+    private let modelContext: ModelContext
+    private let exportService: ExportServiceImpl
+
+    init(modelContext: ModelContext, exportService: ExportServiceImpl = ExportServiceImpl()) {
+        self.modelContext = modelContext
+        self.exportService = exportService
+    }
+
+    // MARK: - Data Loading
+
+    func fetchAvailableMonths() {
+        let descriptor = FetchDescriptor<JournalEntry>(
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        let allEntries = (try? modelContext.fetch(descriptor)) ?? []
+
+        // year-month でグループ化
+        var groupedByMonth: [String: (year: Int, month: Int, entries: [JournalEntry])] = [:]
+        let cal = Calendar.current
+
+        for entry in allEntries {
+            let comps = cal.dateComponents([.year, .month], from: entry.date)
+            guard let year = comps.year, let month = comps.month else { continue }
+            let key = String(format: "%04d%02d", year, month)
+            if groupedByMonth[key] == nil {
+                groupedByMonth[key] = (year: year, month: month, entries: [])
+            }
+            groupedByMonth[key]?.entries.append(entry)
+        }
+
+        // 降順ソートして AvailableMonth に変換
+        availableMonths = groupedByMonth.values
+            .sorted { a, b in
+                if a.year != b.year { return a.year > b.year }
+                return a.month > b.month
+            }
+            .map { group in
+                let totalRecordings = group.entries.reduce(0) { $0 + $1.recordings.count }
+                return AvailableMonth(
+                    year: group.year,
+                    month: group.month,
+                    entryCount: group.entries.count,
+                    recordingCount: totalRecordings
+                )
+            }
+    }
+
+    // MARK: - Export
+
+    func exportMonth() async {
+        guard let selectedMonth else { return }
+
+        let yearMonth = selectedMonth.id  // "yyyyMM"
+        let batchDir = FilePathManager.exportBatchDirectory(for: yearMonth)
+
+        // 対象月のエントリを取得（日付昇順）
+        let cal = Calendar.current
+        var startComps = DateComponents()
+        startComps.year = selectedMonth.year
+        startComps.month = selectedMonth.month
+        startComps.day = 1
+        guard let firstDay = cal.date(from: startComps) else {
+            exportState = .failure("月の開始日を計算できませんでした。")
+            return
+        }
+        let (rangeStart, rangeEnd) = DateHelper.monthRange(for: firstDay, calendar: cal)
+
+        let descriptor = FetchDescriptor<JournalEntry>(
+            predicate: #Predicate {
+                $0.date >= rangeStart && $0.date <= rangeEnd
+            },
+            sortBy: [SortDescriptor(\.date, order: .forward)]
+        )
+        let entries = (try? modelContext.fetch(descriptor)) ?? []
+
+        // 録音がある（音声: 録音あり / テキスト・PDF: 書き起こしあり）エントリのみ対象
+        let targetEntries = entries.filter { entry in
+            switch selectedFormat {
+            case .audio:
+                return !entry.recordings.isEmpty
+            case .text, .pdf:
+                return entry.recordings.contains { $0.transcription != nil && !($0.transcription!.isEmpty) }
+            }
+        }
+
+        guard !targetEntries.isEmpty else {
+            exportState = .failure("選択した月に共有できるデータがありません。")
+            return
+        }
+
+        exportState = .exporting(current: 0, total: targetEntries.count)
+
+        do {
+            try FilePathManager.ensureDirectoryExists(batchDir)
+        } catch {
+            exportState = .failure("出力ディレクトリの作成に失敗しました: \(error.localizedDescription)")
+            return
+        }
+
+        var exportedURLs: [URL] = []
+
+        for (index, entry) in targetEntries.enumerated() {
+            exportState = .exporting(current: index + 1, total: targetEntries.count)
+
+            do {
+                let url: URL
+                switch selectedFormat {
+                case .audio:
+                    url = try await exportService.exportMergedAudio(entry: entry, to: batchDir)
+                case .text:
+                    url = try exportService.exportCombinedTranscript(entry: entry, to: batchDir)
+                case .pdf:
+                    url = try exportService.exportDailyPDF(entry: entry, to: batchDir)
+                }
+                exportedURLs.append(url)
+            } catch {
+                // 個別エントリのエクスポート失敗はスキップして続行
+                continue
+            }
+        }
+
+        if exportedURLs.isEmpty {
+            exportState = .failure("ファイルの生成に失敗しました。")
+        } else {
+            exportState = .done(exportedURLs)
+        }
+    }
+
+    func resetExportState() {
+        exportState = .idle
+    }
+}

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -4,6 +4,7 @@ import SwiftData
 import SwiftUI
 
 struct HomeView: View {
+    private let modelContext: ModelContext
     @State private var viewModel: HomeViewModel
     @State private var transcriptionTargetRecording: Recording?
     @State private var isRecordingModalPresented = false
@@ -15,6 +16,7 @@ struct HomeView: View {
     @State private var summaryPromptStore = SummaryPromptStore()
     @State private var showVocabulary = false
     @State private var showSettings = false
+    @State private var showMonthlyShare = false
 
     init(
         modelContext: ModelContext,
@@ -22,6 +24,7 @@ struct HomeView: View {
         audioPlayer: any AudioPlaying = AudioPlayerService(),
         liveTranscriber: (any LiveTranscribing)? = nil
     ) {
+        self.modelContext = modelContext
         _viewModel = State(
             initialValue: HomeViewModel(
                 modelContext: modelContext,
@@ -59,6 +62,14 @@ struct HomeView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack(spacing: 16) {
+                        Button {
+                            showMonthlyShare = true
+                        } label: {
+                            Image(systemName: "calendar")
+                        }
+                        .accessibilityIdentifier("home.monthlyShareButton")
+                        .accessibilityLabel("月間共有")
+
                         Button {
                             showSettings = true
                         } label: {
@@ -113,6 +124,9 @@ struct HomeView: View {
             }
             .onChange(of: summarizerPreference.type) { _, newType in
                 viewModel.summarizerType = newType
+            }
+            .sheet(isPresented: $showMonthlyShare) {
+                MonthlyShareView(modelContext: modelContext)
             }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)

--- a/MindEcho/MindEcho/Views/MonthlyShareView.swift
+++ b/MindEcho/MindEcho/Views/MonthlyShareView.swift
@@ -1,0 +1,167 @@
+import MindEchoCore
+import SwiftData
+import SwiftUI
+
+struct MonthlyShareView: View {
+    @State private var viewModel: MonthlyShareViewModel
+    @State private var shareItems: [Any]?
+    @Environment(\.dismiss) private var dismiss
+
+    init(modelContext: ModelContext) {
+        _viewModel = State(initialValue: MonthlyShareViewModel(modelContext: modelContext))
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                monthSection
+                formatSection
+            }
+            .navigationTitle("月間共有")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityIdentifier("monthlyShare.closeButton")
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                bottomBar
+            }
+            .onAppear {
+                viewModel.fetchAvailableMonths()
+            }
+            .sheet(
+                isPresented: Binding(
+                    get: { shareItems != nil },
+                    set: { if !$0 { shareItems = nil } }
+                )
+            ) {
+                if let items = shareItems {
+                    ShareSheet(activityItems: items)
+                }
+            }
+            .onChange(of: viewModel.exportState) { _, newState in
+                if case .done(let urls) = newState {
+                    shareItems = urls
+                    viewModel.resetExportState()
+                }
+            }
+            .alert(
+                "エクスポートエラー",
+                isPresented: Binding(
+                    get: {
+                        if case .failure = viewModel.exportState { return true }
+                        return false
+                    },
+                    set: { if !$0 { viewModel.resetExportState() } }
+                )
+            ) {
+                Button("OK") { viewModel.resetExportState() }
+            } message: {
+                if case .failure(let message) = viewModel.exportState {
+                    Text(message)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var monthSection: some View {
+        Section("月を選択") {
+            if viewModel.availableMonths.isEmpty {
+                Text("共有できるデータがありません")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.availableMonths) { month in
+                    Button {
+                        viewModel.selectedMonth = month
+                    } label: {
+                        HStack {
+                            Text(month.displayString)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            if viewModel.selectedMonth == month {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.blue)
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("monthlyShare.monthRow.\(month.id)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var formatSection: some View {
+        Section("形式を選択") {
+            ForEach(MonthlyShareFormat.allCases) { format in
+                Button {
+                    viewModel.selectedFormat = format
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(format.displayName)
+                                .foregroundStyle(.primary)
+                            Text(format.description)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if viewModel.selectedFormat == format {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.blue)
+                        }
+                    }
+                }
+                .accessibilityIdentifier("monthlyShare.formatRow.\(format.rawValue)")
+            }
+        }
+    }
+
+    // MARK: - Bottom Bar
+
+    @ViewBuilder
+    private var bottomBar: some View {
+        VStack(spacing: 8) {
+            if case .exporting(let current, let total) = viewModel.exportState {
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("\(current) / \(total) 件を処理中...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("monthlyShare.progress")
+            }
+
+            Button {
+                Task {
+                    await viewModel.exportMonth()
+                }
+            } label: {
+                Label("共有", systemImage: "square.and.arrow.up")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 4)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(
+                viewModel.selectedMonth == nil
+                    || {
+                        if case .exporting = viewModel.exportState { return true }
+                        return false
+                    }()
+            )
+            .accessibilityIdentifier("monthlyShare.exportButton")
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+        .background(.regularMaterial)
+    }
+}

--- a/MindEcho/MindEchoTests/MonthlyShareViewModelTests.swift
+++ b/MindEcho/MindEchoTests/MonthlyShareViewModelTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import MindEchoCore
+import SwiftData
+import Testing
+
+@testable import MindEcho
+
+@MainActor
+struct MonthlyShareViewModelTests {
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([JournalEntry.self, Recording.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func makeViewModel(container: ModelContainer) -> MonthlyShareViewModel {
+        MonthlyShareViewModel(modelContext: container.mainContext)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        components.timeZone = TimeZone.current
+        return Calendar.current.date(from: components)!
+    }
+
+    private func insertEntry(
+        context: ModelContext,
+        date: Date,
+        transcriptions: [String] = []
+    ) -> JournalEntry {
+        let entry = JournalEntry(date: date)
+        for (i, text) in transcriptions.enumerated() {
+            let recording = Recording(
+                sequenceNumber: i + 1,
+                audioFileName: "test_\(i).m4a",
+                duration: 30
+            )
+            recording.transcription = text
+            entry.recordings.append(recording)
+        }
+        context.insert(entry)
+        return entry
+    }
+
+    // MARK: - fetchAvailableMonths
+
+    @Test func fetchAvailableMonths_groupsByMonth() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = makeViewModel(container: container)
+
+        let mar1 = makeDate(year: 2026, month: 3, day: 10)
+        let mar2 = makeDate(year: 2026, month: 3, day: 20)
+        let feb = makeDate(year: 2026, month: 2, day: 15)
+
+        insertEntry(context: context, date: mar1, transcriptions: ["テスト1"])
+        insertEntry(context: context, date: mar2, transcriptions: ["テスト2"])
+        insertEntry(context: context, date: feb, transcriptions: ["テスト3"])
+
+        vm.fetchAvailableMonths()
+
+        #expect(vm.availableMonths.count == 2)
+    }
+
+    @Test func fetchAvailableMonths_sortedDescending() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = makeViewModel(container: container)
+
+        insertEntry(context: context, date: makeDate(year: 2026, month: 1, day: 5))
+        insertEntry(context: context, date: makeDate(year: 2026, month: 3, day: 5))
+        insertEntry(context: context, date: makeDate(year: 2026, month: 2, day: 5))
+
+        vm.fetchAvailableMonths()
+
+        #expect(vm.availableMonths.count == 3)
+        #expect(vm.availableMonths[0].month == 3)
+        #expect(vm.availableMonths[1].month == 2)
+        #expect(vm.availableMonths[2].month == 1)
+    }
+
+    @Test func fetchAvailableMonths_emptyData() throws {
+        let container = try makeContainer()
+        let vm = makeViewModel(container: container)
+
+        vm.fetchAvailableMonths()
+
+        #expect(vm.availableMonths.isEmpty)
+    }
+
+    @Test func fetchAvailableMonths_countsEntries() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = makeViewModel(container: container)
+
+        insertEntry(context: context, date: makeDate(year: 2026, month: 3, day: 1))
+        insertEntry(context: context, date: makeDate(year: 2026, month: 3, day: 5))
+        insertEntry(context: context, date: makeDate(year: 2026, month: 3, day: 10))
+
+        vm.fetchAvailableMonths()
+
+        #expect(vm.availableMonths.count == 1)
+        #expect(vm.availableMonths[0].entryCount == 3)
+    }
+
+    // MARK: - exportMonth initial states
+
+    @Test func exportMonth_noSelectionDoesNothing() async throws {
+        let container = try makeContainer()
+        let vm = makeViewModel(container: container)
+        vm.selectedMonth = nil
+
+        await vm.exportMonth()
+
+        #expect(vm.exportState == .idle)
+    }
+
+    @Test func exportMonth_noMatchingEntriesFailure() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = makeViewModel(container: container)
+
+        // 2026年2月にエントリを作成
+        let feb = makeDate(year: 2026, month: 2, day: 15)
+        insertEntry(context: context, date: feb, transcriptions: ["テスト"])
+
+        vm.fetchAvailableMonths()
+        // 3月を選択（エントリなし）
+        vm.selectedMonth = MonthlyShareViewModel.AvailableMonth(
+            year: 2026, month: 3, entryCount: 0, recordingCount: 0)
+        vm.selectedFormat = .text
+
+        await vm.exportMonth()
+
+        if case .failure = vm.exportState {
+            // 期待通りの失敗
+        } else {
+            Issue.record("Expected failure state, got \(vm.exportState)")
+        }
+    }
+
+    // MARK: - AvailableMonth.displayString
+
+    @Test func availableMonth_displayStringFormat() {
+        let month = MonthlyShareViewModel.AvailableMonth(
+            year: 2026, month: 3, entryCount: 5, recordingCount: 10
+        )
+        // "2026年3月（5件）" の形式であること
+        #expect(month.displayString.contains("2026"))
+        #expect(month.displayString.contains("3月"))
+        #expect(month.displayString.contains("5件"))
+    }
+
+    // MARK: - MonthlyShareFormat
+
+    @Test func monthlyShareFormat_allCasesPresent() {
+        let cases = MonthlyShareFormat.allCases
+        #expect(cases.contains(.pdf))
+        #expect(cases.contains(.audio))
+        #expect(cases.contains(.text))
+    }
+
+    @Test func monthlyShareFormat_displayNames() {
+        #expect(MonthlyShareFormat.pdf.displayName == "PDF")
+        #expect(MonthlyShareFormat.audio.displayName == "音声")
+        #expect(MonthlyShareFormat.text.displayName == "テキスト")
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/MonthlyShareUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/MonthlyShareUITests.swift
@@ -1,0 +1,117 @@
+import XCTest
+
+final class MonthlyShareUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--seed-multi-month-history"]
+    }
+
+    // MARK: - Tests
+
+    /// 月間共有ボタンをタップするとシートが表示される
+    @MainActor
+    func testMonthlyShareButton_opensSheet() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        // シートの閉じるボタンが表示されることを確認
+        let closeButton = app.buttons["monthlyShare.closeButton"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5))
+    }
+
+    /// シートに月リストが表示される
+    @MainActor
+    func testMonthlyShareSheet_showsAvailableMonths() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        // 月行が少なくとも1件表示されること
+        let monthRows = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'monthlyShare.monthRow.'")
+        )
+        XCTAssertTrue(monthRows.firstMatch.waitForExistence(timeout: 5))
+        XCTAssertGreaterThanOrEqual(monthRows.count, 1)
+    }
+
+    /// シートに形式選択行が3件表示される
+    @MainActor
+    func testMonthlyShareSheet_showsFormatOptions() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        // 3つの形式行が表示されること
+        let pdfRow = app.buttons["monthlyShare.formatRow.pdf"]
+        let audioRow = app.buttons["monthlyShare.formatRow.audio"]
+        let textRow = app.buttons["monthlyShare.formatRow.text"]
+        XCTAssertTrue(pdfRow.waitForExistence(timeout: 5))
+        XCTAssertTrue(audioRow.exists)
+        XCTAssertTrue(textRow.exists)
+    }
+
+    /// 月を選択すると共有ボタンが有効になる
+    @MainActor
+    func testMonthlyShare_selectMonth_enablesExportButton() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        // 月行が表示されるのを待ってから最初の月を選択
+        let monthRows = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'monthlyShare.monthRow.'")
+        )
+        XCTAssertTrue(monthRows.firstMatch.waitForExistence(timeout: 5))
+        monthRows.firstMatch.tap()
+
+        // 共有ボタンが有効になること
+        let exportButton = app.buttons["monthlyShare.exportButton"]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(exportButton.isEnabled)
+    }
+
+    /// 閉じるボタンでシートが閉じる
+    @MainActor
+    func testMonthlyShareSheet_closeButton_dismissesSheet() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        let closeButton = app.buttons["monthlyShare.closeButton"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5))
+        closeButton.tap()
+
+        // シートが閉じてホーム画面に戻ること
+        let homeList = app.collectionViews["home.entryList"]
+        XCTAssertTrue(homeList.waitForExistence(timeout: 5))
+        XCTAssertFalse(closeButton.exists)
+    }
+
+    /// 月を選択せずに共有ボタンは無効
+    @MainActor
+    func testMonthlyShare_noMonthSelected_exportButtonDisabled() throws {
+        app.launch()
+
+        let monthlyShareButton = app.buttons["home.monthlyShareButton"]
+        XCTAssertTrue(monthlyShareButton.waitForExistence(timeout: 5))
+        monthlyShareButton.tap()
+
+        let exportButton = app.buttons["monthlyShare.exportButton"]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
+        XCTAssertFalse(exportButton.isEnabled)
+    }
+}

--- a/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/DateHelper.swift
@@ -40,6 +40,39 @@ public enum DateHelper {
         logicalDate(for: Date(), calendar: calendar)
     }
 
+    /// Returns a formatted month display string, e.g. "2026年3月"
+    public static func monthDisplayString(for date: Date, calendar: Calendar = .current) -> String {
+        var cal = calendar
+        cal.timeZone = TimeZone.current
+        let formatter = DateFormatter()
+        formatter.calendar = cal
+        formatter.timeZone = TimeZone.current
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy年M月"
+        return formatter.string(from: date)
+    }
+
+    /// Returns the first and last logical dates (normalized to noon) of the month containing the given date.
+    /// e.g. a date in March 2026 → (2026-03-01 12:00, 2026-03-31 12:00)
+    public static func monthRange(
+        for date: Date, calendar: Calendar = .current
+    ) -> (start: Date, end: Date) {
+        var cal = calendar
+        cal.timeZone = TimeZone.current
+        let components = cal.dateComponents([.year, .month], from: date)
+        let firstDay = cal.date(from: components) ?? date
+        let lastDay = cal.date(byAdding: DateComponents(month: 1, day: -1), to: firstDay) ?? date
+        return (logicalDate(for: firstDay, calendar: cal), logicalDate(for: lastDay, calendar: cal))
+    }
+
+    /// Returns a yyyyMM string for the given date, e.g. "202603"
+    public static func yearMonthString(for date: Date, calendar: Calendar = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMM"
+        return formatter.string(from: date)
+    }
+
     /// Returns an array of logical dates from `from` to `to` (both inclusive, descending order).
     /// Each date is normalized to noon local time using `logicalDate(for:calendar:)`.
     /// Returns an empty array if `to` is before `from`.

--- a/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/FilePathManager.swift
@@ -52,6 +52,20 @@ public enum FilePathManager {
         return exportsDirectory.appendingPathComponent(fileName)
     }
 
+    /// Returns the monthly batch export subdirectory: Documents/Exports/{yyyyMM}/
+    public static func exportBatchDirectory(for yearMonth: String) -> URL {
+        exportsDirectory.appendingPathComponent(yearMonth, isDirectory: true)
+    }
+
+    /// Returns the daily PDF export URL within a monthly batch directory
+    public static func exportPDFURL(for logicalDate: Date, yearMonth: String) -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd"
+        let fileName = formatter.string(from: logicalDate) + "_journal.pdf"
+        return exportBatchDirectory(for: yearMonth).appendingPathComponent(fileName)
+    }
+
     /// Ensures a directory exists, creating it if necessary
     public static func ensureDirectoryExists(_ url: URL) throws {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Packages/MindEchoCore/Sources/MindEchoCore/MonthlyShareFormat.swift
+++ b/Packages/MindEchoCore/Sources/MindEchoCore/MonthlyShareFormat.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// 月間共有時の出力形式
+public enum MonthlyShareFormat: String, CaseIterable, Identifiable, Sendable {
+    case pdf
+    case audio
+    case text
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .pdf: "PDF"
+        case .audio: "音声"
+        case .text: "テキスト"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .pdf: "日別の書き起こしをPDFで出力"
+        case .audio: "日別のマージ音声ファイルを出力"
+        case .text: "日別のテキストファイルを出力"
+        }
+    }
+}

--- a/docs/ui-test-design.md
+++ b/docs/ui-test-design.md
@@ -74,6 +74,10 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `past.transcription.{date}.{n}` — 過去の録音セル内の書き起こしテキストプレビュー
 - `past.summary.{date}.{n}` — 過去の録音セル内の要約テキストプレビュー
 
+**月間共有**
+
+- `home.monthlyShareButton` — ナビゲーションバーのカレンダーアイコンボタン（月間共有シートを開く）
+
 **語彙設定**
 
 - `home.vocabularyButton` — ナビゲーションバー右端のカスタム語彙設定ボタン（📖アイコン）
@@ -95,6 +99,16 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `settings.summaryPrompt` — 要約プロンプト編集エリア（TextEditor）
 - `settings.summaryPromptResetButton` — 要約プロンプトをデフォルトに戻すボタン
 - `settings.closeButton` — シートを閉じるボタン（×アイコン）
+
+### MonthlyShareView
+
+月間共有シート。月の選択・形式の選択・一括エクスポートを行う。
+
+- `monthlyShare.closeButton` — シートを閉じるボタン（×アイコン）
+- `monthlyShare.monthRow.{yyyyMM}` — 月選択行（例: `monthlyShare.monthRow.202603`）
+- `monthlyShare.formatRow.{format}` — 形式選択行（format = pdf | audio | text）
+- `monthlyShare.exportButton` — 共有ボタン（月が選択されていない場合は無効）
+- `monthlyShare.progress` — エクスポート進捗インジケーター（処理中のみ表示）
 
 ### RecordingModalView
 
@@ -126,7 +140,13 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 - `transcription.summaryText` — 要約結果テキスト
 - `transcription.summaryError` — 要約エラーメッセージ
 
-## テストケース（6カテゴリ・18テスト）
+## テストデータ（Launch Arguments 追加）
+
+| Launch Argument | 用途 |
+|---|---|
+| `--seed-multi-month-history` | 3ヶ月分（当月・先月・2ヶ月前）のエントリを投入（月間共有UIテスト用） |
+
+## テストケース（7カテゴリ・23テスト）
 
 ### 1. NavigationUITests（3テスト）
 
@@ -220,6 +240,19 @@ TabView を廃止し、今日のセクションと過去の履歴セクション
 7. `recording.transcriptionResult`（既存の録音後書き起こし）が表示されることを確認
 
 **既存テストへの影響:** `HomeRecordingUITests.testRecordingModalFlow` は変更不要。`--mock-live-transcription` を含まないため、リアルタイム書き起こし UI は表示されない。
+
+### 7. MonthlyShareUITests（5テスト）
+
+`--uitesting`, `--seed-multi-month-history` を使用。
+
+| テスト | 検証内容 |
+|-------|---------|
+| `testMonthlyShareButton_opensSheet` | ツールバーの月間共有ボタンタップでシートが表示される |
+| `testMonthlyShareSheet_showsAvailableMonths` | シートに月選択行が表示される |
+| `testMonthlyShareSheet_showsFormatOptions` | PDF・音声・テキストの3種類の形式選択行が表示される |
+| `testMonthlyShare_selectMonth_enablesExportButton` | 月を選択すると共有ボタンが有効になる |
+| `testMonthlyShareSheet_closeButton_dismissesSheet` | 閉じるボタンでシートが閉じる |
+| `testMonthlyShare_noMonthSelected_exportButtonDisabled` | 月未選択時は共有ボタンが無効 |
 
 ## テスト対象外（明示的に除外）
 


### PR DESCRIPTION
## Summary

- HomeView のツールバーに📅ボタンを追加し、`MonthlyShareView` シートから月単位の一括共有を実現
- 月選択（エントリがある月のみ、降順表示）→ 形式選択（PDF / 音声 / テキスト）→ 共有ボタン の3ステップUI
- 日別ファイルを複数生成し、iOS Share Sheet でまとめて共有（例: 3月 × テキスト → 日別 `.txt` ×N件）

## 変更ファイル

**新規**
- `MonthlyShareFormat.swift` (MindEchoCore) — 形式 enum (`pdf` / `audio` / `text`)
- `PDFExportService.swift` — `UIGraphicsPDFRenderer` を使った日別 PDF 生成（書き起こし全文）
- `MonthlyShareViewModel.swift` — 月一覧取得・エクスポートオーケストレーション (`@Observable @MainActor`)
- `MonthlyShareView.swift` — 月選択 + 形式選択 + 進捗表示 + ShareSheet のシートUI
- `MonthlyShareViewModelTests.swift` — ユニットテスト 9件
- `MonthlyShareUITests.swift` — UIテスト 6件

**変更**
- `DateHelper.swift` — `monthDisplayString(for:)` / `monthRange(for:)` / `yearMonthString(for:)` 追加
- `FilePathManager.swift` — `exportBatchDirectory(for:)` / `exportPDFURL(for:yearMonth:)` 追加
- `ExportService.swift` — `exportDailyPDF(entry:to:)` 追加
- `HomeView.swift` — カレンダーボタン追加・`MonthlyShareView` sheet 追加
- `MindEchoApp.swift` — `--seed-multi-month-history` launch argument 追加
- `CLAUDE.md` / `docs/ui-test-design.md` — 新型・Accessibility ID・テストケース追記

## Test plan

- [ ] `xcodebuild build` でビルドが通ることを確認
- [ ] `MonthlyShareViewModelTests` — 月グルーピング・降順ソート・エントリカウントのユニットテストが通ること
- [ ] `MonthlyShareUITests` — シート表示・月選択・形式選択・共有ボタン有効化・dismiss のUIテストが通ること
- [ ] シミュレーターで手動確認:
  - ツールバーの📅ボタンタップでシートが開く
  - エントリのある月が正しく表示される
  - PDF / 音声 / テキストそれぞれで共有シートが表示され、日別ファイルが含まれる
  - PDF の内容に日付ヘッダーと書き起こしテキストが含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)