### PR TITLE
Fix PDF transcript text visibility

### DIFF
--- a/MindEcho/MindEcho/Services/ExportService.swift
+++ b/MindEcho/MindEcho/Services/ExportService.swift
@@ -86,6 +86,8 @@ struct ExportServiceImpl: Exporting {
 
             while currentRange.location < attributedText.length {
                 context.beginPage()
+                UIColor.white.setFill()
+                context.cgContext.fill(pageRect)
 
                 let path = CGPath(rect: textRect, transform: nil)
                 let frame = CTFramesetterCreateFrame(


### PR DESCRIPTION
## Summary
- fill each generated PDF page with a white background before drawing transcript text
- keep transcript text rendering in black so exported PDFs remain readable in viewers with dark canvas backgrounds

## Testing
- xcodebuild test -workspace MindEcho.xcworkspace -scheme MindEcho -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MindEchoTests/HomeViewModelTests