### PR TITLE
Add Control Center recording shortcut

### DIFF
--- a/MindEcho/MindEcho.xcodeproj/project.pbxproj
+++ b/MindEcho/MindEcho.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0BA1C00100000002000000A2 /* MindEchoAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000004000000A4 /* MindEchoAudio */; };
 		0BA1C00100000010000000B1 /* DSWaveformImage in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000008000000A8 /* DSWaveformImage */; };
 		0BA1C00100000011000000B2 /* DSWaveformImageViews in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000009000000A9 /* DSWaveformImageViews */; };
+		0BC100010000000100000001 /* MindEchoControls.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0BC100010000001100000011 /* MindEchoControls.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,12 +29,34 @@
 			remoteGlobalIDString = 0BD6D7F92F3856DE00D7656F;
 			remoteInfo = MindEcho;
 		};
+		0BC100010000001B0000001B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0BD6D7F22F3856DE00D7656F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0BC100010000001200000012;
+			remoteInfo = MindEchoControls;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0BC100010000001600000016 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0BC100010000000100000001 /* MindEchoControls.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0BD6D7FA2F3856DE00D7656F /* MindEcho.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MindEcho.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD6D8092F3856E000D7656F /* MindEchoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MindEchoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD6D8132F3856E000D7656F /* MindEchoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MindEchoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BC100010000001100000011 /* MindEchoControls.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MindEchoControls.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -43,6 +66,13 @@
 				Info.plist,
 			);
 			target = 0BD6D7F92F3856DE00D7656F /* MindEcho */;
+		};
+		0BC100010000001A0000001A /* Exceptions for "MindEchoControls" folder in "MindEchoControls" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 0BC100010000001200000012 /* MindEchoControls */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -63,6 +93,14 @@
 		0BD6D8162F3856E000D7656F /* MindEchoUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = MindEchoUITests;
+			sourceTree = "<group>";
+		};
+		0BC100010000001000000010 /* MindEchoControls */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0BC100010000001A0000001A /* Exceptions for "MindEchoControls" folder in "MindEchoControls" target */,
+			);
+			path = MindEchoControls;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -93,6 +131,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0BC100010000001300000013 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -100,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				0BD6D7FC2F3856DE00D7656F /* MindEcho */,
+				0BC100010000001000000010 /* MindEchoControls */,
 				0BD6D80C2F3856E000D7656F /* MindEchoTests */,
 				0BD6D8162F3856E000D7656F /* MindEchoUITests */,
 				0BD6D7FB2F3856DE00D7656F /* Products */,
@@ -110,6 +156,7 @@
 			isa = PBXGroup;
 			children = (
 				0BD6D7FA2F3856DE00D7656F /* MindEcho.app */,
+				0BC100010000001100000011 /* MindEchoControls.appex */,
 				0BD6D8092F3856E000D7656F /* MindEchoTests.xctest */,
 				0BD6D8132F3856E000D7656F /* MindEchoUITests.xctest */,
 			);
@@ -126,10 +173,12 @@
 				0BD6D7F62F3856DE00D7656F /* Sources */,
 				0BD6D7F72F3856DE00D7656F /* Frameworks */,
 				0BD6D7F82F3856DE00D7656F /* Resources */,
+				0BC100010000001600000016 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0BC100010000001C0000001C /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				0BD6D7FC2F3856DE00D7656F /* MindEcho */,
@@ -144,6 +193,28 @@
 			productName = MindEcho;
 			productReference = 0BD6D7FA2F3856DE00D7656F /* MindEcho.app */;
 			productType = "com.apple.product-type.application";
+		};
+		0BC100010000001200000012 /* MindEchoControls */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0BC100010000001700000017 /* Build configuration list for PBXNativeTarget "MindEchoControls" */;
+			buildPhases = (
+				0BC100010000001500000015 /* Sources */,
+				0BC100010000001300000013 /* Frameworks */,
+				0BC100010000001400000014 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0BC100010000001000000010 /* MindEchoControls */,
+			);
+			name = MindEchoControls;
+			packageProductDependencies = (
+			);
+			productName = MindEchoControls;
+			productReference = 0BC100010000001100000011 /* MindEchoControls.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		0BD6D8082F3856E000D7656F /* MindEchoTests */ = {
 			isa = PBXNativeTarget;
@@ -204,6 +275,9 @@
 					0BD6D7F92F3856DE00D7656F = {
 						CreatedOnToolsVersion = 26.2;
 					};
+					0BC100010000001200000012 = {
+						CreatedOnToolsVersion = 26.3;
+					};
 					0BD6D8082F3856E000D7656F = {
 						CreatedOnToolsVersion = 26.2;
 						TestTargetID = 0BD6D7F92F3856DE00D7656F;
@@ -234,6 +308,7 @@
 			projectRoot = "";
 			targets = (
 				0BD6D7F92F3856DE00D7656F /* MindEcho */,
+				0BC100010000001200000012 /* MindEchoControls */,
 				0BD6D8082F3856E000D7656F /* MindEchoTests */,
 				0BD6D8122F3856E000D7656F /* MindEchoUITests */,
 			);
@@ -256,6 +331,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		0BD6D8112F3856E000D7656F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC100010000001400000014 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -286,6 +368,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		0BC100010000001500000015 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -298,6 +387,11 @@
 			isa = PBXTargetDependency;
 			target = 0BD6D7F92F3856DE00D7656F /* MindEcho */;
 			targetProxy = 0BD6D8142F3856E000D7656F /* PBXContainerItemProxy */;
+		};
+		0BC100010000001C0000001C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0BC100010000001200000012 /* MindEchoControls */;
+			targetProxy = 0BC100010000001B0000001B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -549,6 +643,72 @@
 			};
 			name = Release;
 		};
+		0BC100010000001800000018 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = LYMDWEXP2V;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MindEchoControls/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.dev.controls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		0BC100010000001900000019 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = LYMDWEXP2V;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = MindEchoControls/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.controls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 		0BD6D8242F3856E000D7656F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -615,6 +775,15 @@
 			buildConfigurations = (
 				0BD6D8212F3856E000D7656F /* Debug */,
 				0BD6D8222F3856E000D7656F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0BC100010000001700000017 /* Build configuration list for PBXNativeTarget "MindEchoControls" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0BC100010000001800000018 /* Debug */,
+				0BC100010000001900000019 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MindEcho/MindEcho/Info.plist
+++ b/MindEcho/MindEcho/Info.plist
@@ -10,6 +10,17 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.syhash.MindEcho.record</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mindecho</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>録音内容の書き起こしに音声認識を使用します。</string>
 </dict>

--- a/MindEcho/MindEcho/LaunchRouter.swift
+++ b/MindEcho/MindEcho/LaunchRouter.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class LaunchRouter {
+    enum LaunchAction: Equatable {
+        case startRecording
+    }
+
+    private(set) var pendingAction: LaunchAction?
+
+    func request(_ action: LaunchAction) {
+        pendingAction = action
+    }
+
+    func consumePendingAction() {
+        pendingAction = nil
+    }
+
+    func handle(url: URL) {
+        guard let action = action(for: url) else { return }
+        request(action)
+    }
+
+    func action(for url: URL) -> LaunchAction? {
+        guard url.scheme?.lowercased() == "mindecho" else { return nil }
+
+        let host = url.host?.lowercased()
+        let path = url.path.lowercased()
+        if host == "record" || path == "/record" {
+            return .startRecording
+        }
+
+        return nil
+    }
+}

--- a/MindEcho/MindEcho/MindEchoApp.swift
+++ b/MindEcho/MindEcho/MindEchoApp.swift
@@ -10,6 +10,7 @@ struct MindEchoApp: App {
     private let audioRecorder: any AudioRecording
     private let audioPlayer: any AudioPlaying
     private let liveTranscriber: (any LiveTranscribing)?
+    private let launchRouter: LaunchRouter
 
     init() {
         let args = ProcessInfo.processInfo.arguments
@@ -17,6 +18,7 @@ struct MindEchoApp: App {
         let useMockRecorder = args.contains("--mock-recorder")
         let useMockPlayer = args.contains("--mock-player")
         let useMockLiveTranscription = args.contains("--mock-live-transcription")
+        launchRouter = LaunchRouter()
         let schema = Schema([
             JournalEntry.self,
             Recording.self,
@@ -61,6 +63,10 @@ struct MindEchoApp: App {
                 Self.seedTodayWithRecordings(context: context)
             }
         }
+
+        if args.contains("--start-recording") {
+            launchRouter.request(.startRecording)
+        }
     }
 
     var body: some Scene {
@@ -69,8 +75,12 @@ struct MindEchoApp: App {
                 modelContext: modelContainer.mainContext,
                 audioRecorder: audioRecorder,
                 audioPlayer: audioPlayer,
-                liveTranscriber: liveTranscriber
+                liveTranscriber: liveTranscriber,
+                launchRouter: launchRouter
             )
+            .onOpenURL { url in
+                launchRouter.handle(url: url)
+            }
         }
         .modelContainer(modelContainer)
     }

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -15,13 +15,16 @@ struct HomeView: View {
     @State private var summaryPromptStore = SummaryPromptStore()
     @State private var showVocabulary = false
     @State private var showSettings = false
+    private let launchRouter: LaunchRouter
 
     init(
         modelContext: ModelContext,
         audioRecorder: any AudioRecording,
         audioPlayer: any AudioPlaying = AudioPlayerService(),
-        liveTranscriber: (any LiveTranscribing)? = nil
+        liveTranscriber: (any LiveTranscribing)? = nil,
+        launchRouter: LaunchRouter
     ) {
+        self.launchRouter = launchRouter
         _viewModel = State(
             initialValue: HomeViewModel(
                 modelContext: modelContext,
@@ -95,6 +98,7 @@ struct HomeView: View {
                 viewModel.summaryInstruction = summaryPromptStore.instruction
                 viewModel.summarizerType = summarizerPreference.type
                 viewModel.fetchAllEntries()
+                handlePendingLaunchAction()
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
                 viewModel.vocabularyWords = newWords
@@ -113,6 +117,9 @@ struct HomeView: View {
             }
             .onChange(of: summarizerPreference.type) { _, newType in
                 viewModel.summarizerType = newType
+            }
+            .onChange(of: launchRouter.pendingAction) { _, _ in
+                handlePendingLaunchAction()
             }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
@@ -150,6 +157,17 @@ struct HomeView: View {
                 .accessibilityIdentifier("home.transcriptionSheet")
             }
         }
+    }
+
+    private func handlePendingLaunchAction() {
+        guard launchRouter.pendingAction == .startRecording else { return }
+        guard !isRecordingModalPresented, !viewModel.isRecording else {
+            launchRouter.consumePendingAction()
+            return
+        }
+
+        launchRouter.consumePendingAction()
+        isRecordingModalPresented = true
     }
 
     // MARK: - Today Section

--- a/MindEcho/MindEchoControls/Assets.xcassets/Contents.json
+++ b/MindEcho/MindEchoControls/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MindEcho/MindEchoControls/Info.plist
+++ b/MindEcho/MindEchoControls/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>MindEcho Controls</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/MindEcho/MindEchoControls/MindEchoControlsBundle.swift
+++ b/MindEcho/MindEchoControls/MindEchoControlsBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct MindEchoControlsBundle: WidgetBundle {
+    var body: some Widget {
+        RecordControl()
+    }
+}

--- a/MindEcho/MindEchoControls/RecordControl.swift
+++ b/MindEcho/MindEchoControls/RecordControl.swift
@@ -1,0 +1,24 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct RecordControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "com.syhash.MindEcho.recordControl") {
+            ControlWidgetButton(action: StartRecordingIntent()) {
+                Label("録音開始", systemImage: "mic.fill")
+            }
+        }
+        .displayName("録音開始")
+        .description("MindEchoを開いてすぐに録音を始めます。")
+    }
+}
+
+struct StartRecordingIntent: AppIntent {
+    static let title: LocalizedStringResource = "録音開始"
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: OpenURLIntent(URL(string: "mindecho://record")!))
+    }
+}

--- a/MindEcho/MindEchoTests/LaunchRouterTests.swift
+++ b/MindEcho/MindEchoTests/LaunchRouterTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import MindEcho
+
+@MainActor
+struct LaunchRouterTests {
+    @Test func handleRecordURL_setsPendingStartRecording() {
+        let router = LaunchRouter()
+
+        router.handle(url: URL(string: "mindecho://record")!)
+
+        #expect(router.pendingAction == .startRecording)
+    }
+
+    @Test func consumePendingAction_clearsAction() {
+        let router = LaunchRouter()
+        router.request(.startRecording)
+
+        router.consumePendingAction()
+
+        #expect(router.pendingAction == nil)
+    }
+
+    @Test func unrelatedURL_isIgnored() {
+        let router = LaunchRouter()
+
+        router.handle(url: URL(string: "https://example.com")!)
+
+        #expect(router.pendingAction == nil)
+    }
+}

--- a/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/HomeRecordingUITests.swift
@@ -98,6 +98,17 @@ final class HomeRecordingUITests: XCTestCase {
     }
 
     @MainActor
+    func testLaunchArgumentStartRecording_opensRecordingModal() throws {
+        app.launchArguments.append("--start-recording")
+        app.launch()
+
+        app.tap()
+
+        XCTAssertTrue(app.staticTexts["recording.duration"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["recording.stopButton"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
     func testAddRecordingToPastDate() throws {
         // TODO: モーダルを閉じた後に過去エントリへ追加した録音行が UI に反映されない問題が未解決のためスキップ。
         // SwiftData の inverse 関係（recording.entry 経由）での保存方法または


### PR DESCRIPTION
## Summary
- add a MindEchoControls widget extension with a Control Center record button
- route mindecho://record launches into the app and auto-open the recording modal
- add launch router coverage and a UI test for launch-triggered recording

## Testing
- xcodebuild -project MindEcho/MindEcho.xcodeproj -scheme MindEcho -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' build