### PR TITLE
Add quick recording Control Center button

### DIFF
--- a/MindEcho/MindEcho.xcodeproj/project.pbxproj
+++ b/MindEcho/MindEcho.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B5F20012FB33A0000A00001 /* MindEchoWidgetExtensionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0B12710A2FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0B12710D2FB21D2E00A71E95 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B12710C2FB21D2E00A71E95 /* WidgetKit.framework */; };
 		0B12710F2FB21D2E00A71E95 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B12710E2FB21D2E00A71E95 /* SwiftUI.framework */; };
 		0BA1C00100000001000000A1 /* MindEchoCore in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000003000000A3 /* MindEchoCore */; };
@@ -16,6 +17,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0B5F20022FB33A0000A00002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0BD6D7F22F3856DE00D7656F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0B1271092FB21D2E00A71E95;
+			remoteInfo = MindEchoWidgetExtensionExtension;
+		};
 		0BD6D80A2F3856E000D7656F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0BD6D7F22F3856DE00D7656F /* Project object */;
@@ -31,6 +39,20 @@
 			remoteInfo = MindEcho;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0B5F20042FB33A0000A00004 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0B5F20012FB33A0000A00001 /* MindEchoWidgetExtensionExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0B12710A2FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MindEchoWidgetExtensionExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -189,10 +211,12 @@
 				0BD6D7F62F3856DE00D7656F /* Sources */,
 				0BD6D7F72F3856DE00D7656F /* Frameworks */,
 				0BD6D7F82F3856DE00D7656F /* Resources */,
+				0B5F20042FB33A0000A00004 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0B5F20032FB33A0000A00003 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				0BD6D7FC2F3856DE00D7656F /* MindEcho */,
@@ -370,6 +394,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0B5F20032FB33A0000A00003 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0B1271092FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension */;
+			targetProxy = 0B5F20022FB33A0000A00002 /* PBXContainerItemProxy */;
+		};
 		0BD6D80B2F3856E000D7656F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0BD6D7F92F3856DE00D7656F /* MindEcho */;
@@ -389,7 +418,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = LYMDWEXP2V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MindEchoWidgetExtension/Info.plist;
@@ -402,7 +431,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.MindEchoWidgetExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.dev.MindEchoWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -420,7 +449,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = LYMDWEXP2V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MindEchoWidgetExtension/Info.plist;

--- a/MindEcho/MindEcho.xcodeproj/project.pbxproj
+++ b/MindEcho/MindEcho.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B12710D2FB21D2E00A71E95 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B12710C2FB21D2E00A71E95 /* WidgetKit.framework */; };
+		0B12710F2FB21D2E00A71E95 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B12710E2FB21D2E00A71E95 /* SwiftUI.framework */; };
 		0BA1C00100000001000000A1 /* MindEchoCore in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000003000000A3 /* MindEchoCore */; };
 		0BA1C00100000002000000A2 /* MindEchoAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000004000000A4 /* MindEchoAudio */; };
 		0BA1C00100000010000000B1 /* DSWaveformImage in Frameworks */ = {isa = PBXBuildFile; productRef = 0BA1C00100000008000000A8 /* DSWaveformImage */; };
@@ -31,12 +33,22 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0B12710A2FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MindEchoWidgetExtensionExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B12710C2FB21D2E00A71E95 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		0B12710E2FB21D2E00A71E95 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		0BD6D7FA2F3856DE00D7656F /* MindEcho.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MindEcho.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD6D8092F3856E000D7656F /* MindEchoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MindEchoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD6D8132F3856E000D7656F /* MindEchoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MindEchoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0B12711C2FB21D2F00A71E95 /* Exceptions for "MindEchoWidgetExtension" folder in "MindEchoWidgetExtensionExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 0B1271092FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension */;
+		};
 		0B20B0D82F420F2E00AF8690 /* Exceptions for "MindEcho" folder in "MindEcho" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -47,6 +59,14 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		0B1271102FB21D2E00A71E95 /* MindEchoWidgetExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0B12711C2FB21D2F00A71E95 /* Exceptions for "MindEchoWidgetExtension" folder in "MindEchoWidgetExtensionExtension" target */,
+			);
+			path = MindEchoWidgetExtension;
+			sourceTree = "<group>";
+		};
 		0BD6D7FC2F3856DE00D7656F /* MindEcho */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -68,6 +88,15 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0B1271072FB21D2E00A71E95 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B12710F2FB21D2E00A71E95 /* SwiftUI.framework in Frameworks */,
+				0B12710D2FB21D2E00A71E95 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0BD6D7F72F3856DE00D7656F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -96,12 +125,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0B12710B2FB21D2E00A71E95 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0B12710C2FB21D2E00A71E95 /* WidgetKit.framework */,
+				0B12710E2FB21D2E00A71E95 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		0BD6D7F12F3856DE00D7656F = {
 			isa = PBXGroup;
 			children = (
 				0BD6D7FC2F3856DE00D7656F /* MindEcho */,
 				0BD6D80C2F3856E000D7656F /* MindEchoTests */,
 				0BD6D8162F3856E000D7656F /* MindEchoUITests */,
+				0B1271102FB21D2E00A71E95 /* MindEchoWidgetExtension */,
+				0B12710B2FB21D2E00A71E95 /* Frameworks */,
 				0BD6D7FB2F3856DE00D7656F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -112,6 +152,7 @@
 				0BD6D7FA2F3856DE00D7656F /* MindEcho.app */,
 				0BD6D8092F3856E000D7656F /* MindEchoTests.xctest */,
 				0BD6D8132F3856E000D7656F /* MindEchoUITests.xctest */,
+				0B12710A2FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -119,6 +160,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0B1271092FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0B12711D2FB21D2F00A71E95 /* Build configuration list for PBXNativeTarget "MindEchoWidgetExtensionExtension" */;
+			buildPhases = (
+				0B1271062FB21D2E00A71E95 /* Sources */,
+				0B1271072FB21D2E00A71E95 /* Frameworks */,
+				0B1271082FB21D2E00A71E95 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0B1271102FB21D2E00A71E95 /* MindEchoWidgetExtension */,
+			);
+			name = MindEchoWidgetExtensionExtension;
+			packageProductDependencies = (
+			);
+			productName = MindEchoWidgetExtensionExtension;
+			productReference = 0B12710A2FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		0BD6D7F92F3856DE00D7656F /* MindEcho */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0BD6D81D2F3856E000D7656F /* Build configuration list for PBXNativeTarget "MindEcho" */;
@@ -198,9 +261,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2620;
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
+					0B1271092FB21D2E00A71E95 = {
+						CreatedOnToolsVersion = 26.4.1;
+					};
 					0BD6D7F92F3856DE00D7656F = {
 						CreatedOnToolsVersion = 26.2;
 					};
@@ -236,11 +302,19 @@
 				0BD6D7F92F3856DE00D7656F /* MindEcho */,
 				0BD6D8082F3856E000D7656F /* MindEchoTests */,
 				0BD6D8122F3856E000D7656F /* MindEchoUITests */,
+				0B1271092FB21D2E00A71E95 /* MindEchoWidgetExtensionExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0B1271082FB21D2E00A71E95 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0BD6D7F82F3856DE00D7656F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -265,6 +339,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0B1271062FB21D2E00A71E95 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		0BD6D7F62F3856DE00D7656F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -302,6 +383,68 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0B12711A2FB21D2F00A71E95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LYMDWEXP2V;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MindEchoWidgetExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = MindEchoWidgetExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.MindEchoWidgetExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0B12711B2FB21D2F00A71E95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = LYMDWEXP2V;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MindEchoWidgetExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = MindEchoWidgetExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.syhash.MindEcho.MindEchoWidgetExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		0BD6D81B2F3856E000D7656F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -592,6 +735,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0B12711D2FB21D2F00A71E95 /* Build configuration list for PBXNativeTarget "MindEchoWidgetExtensionExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0B12711A2FB21D2F00A71E95 /* Debug */,
+				0B12711B2FB21D2F00A71E95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		0BD6D7F52F3856DE00D7656F /* Build configuration list for PBXProject "MindEcho" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MindEcho/MindEcho/Info.plist
+++ b/MindEcho/MindEcho/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.syhash.MindEcho.quickRecord</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mindecho</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>UIFileSharingEnabled</key>

--- a/MindEcho/MindEcho/QuickRecordIntent.swift
+++ b/MindEcho/MindEcho/QuickRecordIntent.swift
@@ -1,0 +1,56 @@
+import AppIntents
+import Foundation
+import UIKit
+
+enum QuickRecordDestination: String, AppEnum {
+    case quickRecord
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "MindEcho")
+    static let caseDisplayRepresentations: [QuickRecordDestination: DisplayRepresentation] = [
+        .quickRecord: DisplayRepresentation(title: "クイック録音", image: .init(systemName: "mic.fill"))
+    ]
+}
+
+struct QuickRecordIntent: OpenIntent, @preconcurrency UISceneAppIntent {
+    static let title: LocalizedStringResource = "クイック録音"
+    static let persistentIdentifier = "com.syhash.MindEcho.quickRecordIntent"
+
+    @Parameter(title: "Destination")
+    var target: QuickRecordDestination
+
+    init() {
+        target = .quickRecord
+    }
+
+    init(target: QuickRecordDestination) {
+        self.target = target
+    }
+
+    @MainActor
+    func performNavigation(forScene scene: UIScene) {
+        QuickRecordLaunchRouter.shared.requestQuickRecord()
+    }
+}
+
+@MainActor
+final class QuickRecordLaunchRouter {
+    static let shared = QuickRecordLaunchRouter()
+    private var hasPendingRequest = false
+
+    private init() {}
+
+    func requestQuickRecord() {
+        hasPendingRequest = true
+        NotificationCenter.default.post(name: .quickRecordRequested, object: nil)
+    }
+
+    func consumePendingRequest() -> Bool {
+        guard hasPendingRequest else { return false }
+        hasPendingRequest = false
+        return true
+    }
+}
+
+extension Notification.Name {
+    static let quickRecordRequested = Notification.Name("com.syhash.MindEcho.quickRecordRequested")
+}

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -114,6 +114,9 @@ struct HomeView: View {
             .onChange(of: summarizerPreference.type) { _, newType in
                 viewModel.summarizerType = newType
             }
+            .onOpenURL { url in
+                handleIncomingURL(url)
+            }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
             }
@@ -149,6 +152,22 @@ struct HomeView: View {
                 )
                 .accessibilityIdentifier("home.transcriptionSheet")
             }
+        }
+    }
+
+    // MARK: - Deep Links
+
+    private func handleIncomingURL(_ url: URL) {
+        guard url.scheme == "mindecho", url.host == "quick-record" else { return }
+        shareItems = nil
+        transcriptionTargetRecording = nil
+        showVocabulary = false
+        showSettings = false
+        viewModel.recordingTargetDate = nil
+
+        Task { @MainActor in
+            await Task.yield()
+            isRecordingModalPresented = true
         }
     }
 

--- a/MindEcho/MindEcho/Views/HomeView.swift
+++ b/MindEcho/MindEcho/Views/HomeView.swift
@@ -95,6 +95,9 @@ struct HomeView: View {
                 viewModel.summaryInstruction = summaryPromptStore.instruction
                 viewModel.summarizerType = summarizerPreference.type
                 viewModel.fetchAllEntries()
+                if QuickRecordLaunchRouter.shared.consumePendingRequest() {
+                    presentQuickRecording()
+                }
             }
             .onChange(of: vocabularyStore.words) { _, newWords in
                 viewModel.vocabularyWords = newWords
@@ -116,6 +119,9 @@ struct HomeView: View {
             }
             .onOpenURL { url in
                 handleIncomingURL(url)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .quickRecordRequested)) { _ in
+                presentQuickRecording()
             }
             .sheet(isPresented: $showVocabulary) {
                 VocabularyView(store: vocabularyStore)
@@ -159,6 +165,10 @@ struct HomeView: View {
 
     private func handleIncomingURL(_ url: URL) {
         guard url.scheme == "mindecho", url.host == "quick-record" else { return }
+        presentQuickRecording()
+    }
+
+    private func presentQuickRecording() {
         shareItems = nil
         transcriptionTargetRecording = nil
         showVocabulary = false

--- a/MindEcho/MindEchoWidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/MindEcho/MindEchoWidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MindEcho/MindEchoWidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MindEcho/MindEchoWidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MindEcho/MindEchoWidgetExtension/Assets.xcassets/Contents.json
+++ b/MindEcho/MindEchoWidgetExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MindEcho/MindEchoWidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/MindEcho/MindEchoWidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MindEcho/MindEchoWidgetExtension/Info.plist
+++ b/MindEcho/MindEchoWidgetExtension/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtension.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtension.swift
@@ -1,0 +1,84 @@
+//
+//  MindEchoWidgetExtension.swift
+//  MindEchoWidgetExtension
+//
+//  Created by sy-hash on 2026/05/11.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), emoji: "😀")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let entry = SimpleEntry(date: Date(), emoji: "😀")
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, emoji: "😀")
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+
+//    func relevances() async -> WidgetRelevances<Void> {
+//        // Generate a list containing the contexts this widget is relevant in.
+//    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let emoji: String
+}
+
+struct MindEchoWidgetExtensionEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Emoji:")
+            Text(entry.emoji)
+        }
+    }
+}
+
+struct MindEchoWidgetExtension: Widget {
+    let kind: String = "MindEchoWidgetExtension"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            if #available(iOS 17.0, *) {
+                MindEchoWidgetExtensionEntryView(entry: entry)
+                    .containerBackground(.fill.tertiary, for: .widget)
+            } else {
+                MindEchoWidgetExtensionEntryView(entry: entry)
+                    .padding()
+                    .background()
+            }
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+    }
+}
+
+#Preview(as: .systemSmall) {
+    MindEchoWidgetExtension()
+} timeline: {
+    SimpleEntry(date: .now, emoji: "😀")
+    SimpleEntry(date: .now, emoji: "🤩")
+}

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionBundle.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionBundle.swift
@@ -1,0 +1,17 @@
+//
+//  MindEchoWidgetExtensionBundle.swift
+//  MindEchoWidgetExtension
+//
+//  Created by sy-hash on 2026/05/11.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct MindEchoWidgetExtensionBundle: WidgetBundle {
+    var body: some Widget {
+        MindEchoWidgetExtension()
+        MindEchoWidgetExtensionControl()
+    }
+}

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionBundle.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionBundle.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @main
 struct MindEchoWidgetExtensionBundle: WidgetBundle {
     var body: some Widget {
-        MindEchoWidgetExtension()
         MindEchoWidgetExtensionControl()
     }
 }

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
@@ -15,7 +15,7 @@ struct MindEchoWidgetExtensionControl: ControlWidget {
             kind: "com.syhash.MindEcho.quickRecord"
         ) {
             ControlWidgetButton(
-                action: OpenURLIntent(URL(string: "mindecho://quick-record")!)
+                action: QuickRecordIntent(target: .quickRecord)
             ) {
                 Label("クイック録音", systemImage: "mic.fill")
             }

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
@@ -12,43 +12,15 @@ import WidgetKit
 struct MindEchoWidgetExtensionControl: ControlWidget {
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(
-            kind: "com.syhash.MindEcho.MindEchoWidgetExtension",
-            provider: Provider()
-        ) { value in
-            ControlWidgetToggle(
-                "Start Timer",
-                isOn: value,
-                action: StartTimerIntent()
-            ) { isRunning in
-                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            kind: "com.syhash.MindEcho.quickRecord"
+        ) {
+            ControlWidgetButton(
+                action: OpenURLIntent(URL(string: "mindecho://quick-record")!)
+            ) {
+                Label("クイック録音", systemImage: "mic.fill")
             }
         }
-        .displayName("Timer")
-        .description("A an example control that runs a timer.")
-    }
-}
-
-extension MindEchoWidgetExtensionControl {
-    struct Provider: ControlValueProvider {
-        var previewValue: Bool {
-            false
-        }
-
-        func currentValue() async throws -> Bool {
-            let isRunning = true // Check if the timer is running
-            return isRunning
-        }
-    }
-}
-
-struct StartTimerIntent: SetValueIntent {
-    static let title: LocalizedStringResource = "Start a timer"
-
-    @Parameter(title: "Timer is running")
-    var value: Bool
-
-    func perform() async throws -> some IntentResult {
-        // Start / stop the timer based on `value`.
-        return .result()
+        .displayName("クイック録音")
+        .description("MindEchoを開いて録音を開始します。")
     }
 }

--- a/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
+++ b/MindEcho/MindEchoWidgetExtension/MindEchoWidgetExtensionControl.swift
@@ -1,0 +1,54 @@
+//
+//  MindEchoWidgetExtensionControl.swift
+//  MindEchoWidgetExtension
+//
+//  Created by sy-hash on 2026/05/11.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct MindEchoWidgetExtensionControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: "com.syhash.MindEcho.MindEchoWidgetExtension",
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value,
+                action: StartTimerIntent()
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension MindEchoWidgetExtensionControl {
+    struct Provider: ControlValueProvider {
+        var previewValue: Bool {
+            false
+        }
+
+        func currentValue() async throws -> Bool {
+            let isRunning = true // Check if the timer is running
+            return isRunning
+        }
+    }
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    func perform() async throws -> some IntentResult {
+        // Start / stop the timer based on `value`.
+        return .result()
+    }
+}

--- a/MindEcho/MindEchoWidgetExtension/QuickRecordIntent.swift
+++ b/MindEcho/MindEchoWidgetExtension/QuickRecordIntent.swift
@@ -1,0 +1,56 @@
+import AppIntents
+import Foundation
+import UIKit
+
+enum QuickRecordDestination: String, AppEnum {
+    case quickRecord
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "MindEcho")
+    static let caseDisplayRepresentations: [QuickRecordDestination: DisplayRepresentation] = [
+        .quickRecord: DisplayRepresentation(title: "クイック録音", image: .init(systemName: "mic.fill"))
+    ]
+}
+
+struct QuickRecordIntent: OpenIntent, @preconcurrency UISceneAppIntent {
+    static let title: LocalizedStringResource = "クイック録音"
+    static let persistentIdentifier = "com.syhash.MindEcho.quickRecordIntent"
+
+    @Parameter(title: "Destination")
+    var target: QuickRecordDestination
+
+    init() {
+        target = .quickRecord
+    }
+
+    init(target: QuickRecordDestination) {
+        self.target = target
+    }
+
+    @MainActor
+    func performNavigation(forScene scene: UIScene) {
+        QuickRecordLaunchRouter.shared.requestQuickRecord()
+    }
+}
+
+@MainActor
+final class QuickRecordLaunchRouter {
+    static let shared = QuickRecordLaunchRouter()
+    private var hasPendingRequest = false
+
+    private init() {}
+
+    func requestQuickRecord() {
+        hasPendingRequest = true
+        NotificationCenter.default.post(name: .quickRecordRequested, object: nil)
+    }
+
+    func consumePendingRequest() -> Bool {
+        guard hasPendingRequest else { return false }
+        hasPendingRequest = false
+        return true
+    }
+}
+
+extension Notification.Name {
+    static let quickRecordRequested = Notification.Name("com.syhash.MindEcho.quickRecordRequested")
+}


### PR DESCRIPTION
## Summary
- add a WidgetKit Control Center button for quick recording
- register the mindecho://quick-record URL scheme and route it to the recording modal
- remove the home screen widget from the widget bundle so the extension only provides the control

## Verification
- Built the MindEcho scheme for iOS Simulator successfully
- Launched mindecho://quick-record in the simulator and confirmed it opens MindEcho to the recording screen with recording started