### PR TITLE
Stabilize audio share UI test

### DIFF
--- a/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
+++ b/MindEcho/MindEchoUITests/Tests/EntryDetailUITests.swift
@@ -45,7 +45,7 @@ final class EntryDetailUITests: XCTestCase {
 
         // UIActivityViewController should appear after audio export & merge
         let activityList = app.otherElements["ActivityListView"]
-        XCTAssertTrue(activityList.waitForExistence(timeout: 15))
+        XCTAssertTrue(activityList.waitForExistence(timeout: 45))
     }
 
     @MainActor


### PR DESCRIPTION
## 概要

音声共有 UI test が CI 上で Activity sheet 表示待ちに間に合わず失敗したため、音声 export/merge 後の待機時間を延長しました。

## 変更の種類

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] UI/デザイン変更
- [ ] ドキュメント更新
- [x] テストの追加・修正
- [x] ビルド・CI設定の変更
- [ ] その他

## 変更内容

- `EntryDetailUITests.testShareButton_presentsActivitySheet` の Activity sheet 待機時間を 15 秒から 45 秒へ延長
- 音声共有は audio export/merge を挟むため、CI runner の遅延に耐える設定に変更

## 影響範囲

- 対象画面: なし
- 対象機能: UI test の音声共有確認

## スクリーンショット / 動画

UI変更なし

## テスト

- [ ] ユニットテストを追加・更新した
- [x] UIテストを追加・更新した
- [x] シミュレータで動作確認した
- [ ] 実機で動作確認した

実行済み:

- `xcrun swift-format lint --recursive --strict MindEcho/MindEcho Packages/`
- `xcodebuild build-for-testing -workspace MindEcho.xcworkspace -scheme MindEcho -destination 'platform=iOS Simulator,id=FA25AA69-54D5-4AB0-B9AC-3204675F3D4F' -derivedDataPath /private/tmp/mind-echo-DerivedData`
- `xcodebuild test-without-building -workspace MindEcho.xcworkspace -scheme MindEcho -destination 'platform=iOS Simulator,id=FA25AA69-54D5-4AB0-B9AC-3204675F3D4F' -derivedDataPath /private/tmp/mind-echo-DerivedData -only-testing:MindEchoUITests/EntryDetailUITests/testShareButton_presentsActivitySheet`

## チェックリスト

- [x] コードがビルドできることを確認した
- [x] SwiftLint等の警告を解消した
- [x] 不要なデバッグコード・print文を削除した
- [x] 既存の機能にデグレがないことを確認した

## 関連Issue

なし

## レビュアーへの補足

PR #116 の CI で `EntryDetailUITests.testShareButton_presentsActivitySheet` が `ActivityListView` の 15 秒待機を超えて失敗したためのフォローアップです。ローカル単体実行では修正後に成功しています。
